### PR TITLE
First functional release of trafficgen for crucible

### DIFF
--- a/rickshaw.json
+++ b/rickshaw.json
@@ -1,0 +1,44 @@
+{
+    "rickshaw-benchmark": {
+        "schema": {
+            "version": "2020.05.18"
+        }
+    },
+    "benchmark": "trafficgen",
+    "controller": {
+        "post-script": "%bench-dir%trafficgen-post-process"
+    },
+    "client": {
+        "files-from-controller": [
+            {
+                "src": "%bench-dir%/trafficgen-get-runtime",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/trafficgen-infra",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/trafficgen-client",
+                "dest": "/usr/bin/"
+            }
+        ],
+        "runtime": "trafficgen-get-runtime",
+        "infra": "trafficgen-infra",
+        "start": "trafficgen-client"
+    },
+    "server": {
+        "files-from-controller": [
+            {
+                "src": "%bench-dir%/trafficgen-server-start",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/trafficgen-server-stop",
+                "dest": "/usr/bin/"
+            }
+        ],
+        "start": "trafficgen-server-start",
+        "stop": "trafficgen-server-stop"
+    }
+}

--- a/trafficgen-client
+++ b/trafficgen-client
@@ -1,0 +1,134 @@
+#!/bin/bash
+exec >trafficgen-client-stderrout.txt
+exec 2>&1
+
+echo "args: $@"
+echo
+if [ -z "$RS_CS_LABEL" ]; then
+    echo "RS_CS_LABEL is not defined, exiting"
+    exit 1
+else
+    echo "RS_CS_LABEL: $RS_CS_LABEL"
+    echo
+fi
+echo "hostname: `hostname`"
+echo
+echo "pwd:"
+/bin/pwd
+echo
+echo "ls -alR:"
+/bin/ls -alR
+echo
+# defaults
+tgen_dir=/opt/trafficgen
+max_loss_pct=0.002
+rate=100
+rate_unit="%"
+one_shot="0"
+longopts="client-devices:,server-devices:,cpus:,max-loss-pct:,rate:,rate-unit:,one-shot:"
+opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+if [ $? -ne 0 ]; then
+    printf -- "\tUnrecognized option specified\n\n"
+    exit 1
+fi
+eval set -- "$opts";
+while true; do
+    case "$1" in
+        --client-devices)
+            shift;
+            devices=$1
+            shift;
+            ;;
+        --server-devices)
+            # We don't need these for the client
+            shift;
+            shift;
+            ;;
+        --cpus)
+            shift;
+            cpus=$1
+            shift;
+            ;;
+        --max-loss-pct)
+            shift;
+            max_loss_pct=$1
+            shift
+            ;;
+        --rate)
+            shift;
+            rate=$1
+            shift
+            ;;
+        --rate-unit)
+            shift;
+            rate_unit=$1
+            shift
+            ;;
+        --one-shot)
+            shift;
+            one_shot="$1"
+            shift
+            ;;
+        --)
+            shift;
+            break
+            ;;
+        *)
+            echo "Invalid option: $1"
+            exit 1
+    esac
+done
+
+id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
+re='^[1-9][0-9]*$'
+if [[ ! "$id" =~ $re ]]; then
+    echo "ID must a be a positive interger, exiting"
+    exit 1
+fi
+
+echo "These files exist in ./msgs/rx:"
+/bin/ls -l msgs/rx
+file="msgs/rx/endpoint-start:1"
+if [ -e "$file" ]; then
+    echo "Found $file"
+    dstmac0=`jq -r '.macs[0]' $file`
+    if [ ! -z "$dstmac0" ]; then
+        echo "Found MAC0 $dstmac0"
+    fi
+    dstmac1=`jq -r '.macs[1]' $file`
+    if [ ! -z "$dstmac1" ]; then
+        echo "Found MAC1 $dstmac1"
+    fi
+fi
+
+
+if [ ! -e $tgen_dir ]; then
+    echo "ERROR: $tgen_dir not found"
+    exit 1
+fi
+pushd $tgen_dir
+git remote update
+git branch -a
+git checkout crucible1
+git status
+if [ ! -x binary-search.py ]; then
+    echo "ERROR: binary-search.py is missing or not executable"
+    exit 1
+fi
+if [ ! -e /usr/bin/python ]; then
+    echo "/usr/bin/python not found"
+    if [ -e /usr/bin/python3 ]; then
+        echo "creating symlink from /usr/bin/python3"
+        ln -sf /usr/bin/python3 /usr/bin/python
+        /bin/ls -l /usr/bin/python
+    else
+        echo "can't find /usr/bin/python3 either, exiting"
+        exit 1
+    fi
+fi
+
+echo "Starting binary-search.sh"
+./binary-search.py --device-pairs 0:1 --max-loss-pct 1  --measure-latency 1 --use-src-mac-flows 0 --use-dst-mac-flows 0 --no-promisc --dst-macs $dstmac0,$dstmac1
+echo "Shutting down TRex"
+kill `pgrep _t-rex-64`
+exit 0

--- a/trafficgen-get-runtime
+++ b/trafficgen-get-runtime
@@ -1,0 +1,8 @@
+#!/bin/bash
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+
+# TODO: implement a way to extend runtime during test
+# For now, use a very long duration that is longer than most binary-searches
+# FYI: It should be possible to provide an accurate run time if the test includes --one-shot
+echo 28800

--- a/trafficgen-infra
+++ b/trafficgen-infra
@@ -1,0 +1,132 @@
+#!/bin/bash
+exec >trafficgen-infra-stderrout.txt
+exec 2>&1
+
+echo "args: $@"
+echo
+if [ -z "$RS_CS_LABEL" ]; then
+    echo "RS_CS_LABEL is not defined, exiting"
+    exit 1
+else
+    echo "RS_CS_LABEL: $RS_CS_LABEL"
+    echo
+fi
+echo "hostname: `hostname`"
+echo
+echo "pwd:"
+/bin/pwd
+echo
+echo "ls -alR:"
+/bin/ls -alR
+echo
+# defaults
+tgen_dir=/opt/trafficgen
+max_loss_pct=0.002
+rate=100
+rate_unit="%"
+one_shot="0"
+longopts="client-devices:,server-devices:,cpus:,max-loss-pct:,rate:,rate-unit:,one-shot:"
+opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+if [ $? -ne 0 ]; then
+    printf -- "\tUnrecognized option specified\n\n"
+    exit 1
+fi
+eval set -- "$opts";
+while true; do
+    case "$1" in
+        --client-devices)
+            shift;
+            devices=$1
+            shift;
+            ;;
+        --server-devices)
+            # We don't need these for the client
+            shift;
+            shift;
+            ;;
+        --cpus)
+            shift;
+            cpus=$1
+            shift;
+            ;;
+        --max-loss-pct)
+            shift;
+            max_loss_pct=$1
+            shift
+            ;;
+        --rate)
+            shift;
+            rate=$1
+            shift
+            ;;
+        --rate-unit)
+            shift;
+            rate_unit=$1
+            shift
+            ;;
+        --one-shot)
+            shift;
+            one_shot="$1"
+            shift
+            ;;
+        --)
+            shift;
+            break
+            ;;
+        *)
+            echo "Invalid option: $1"
+            exit 1
+    esac
+done
+
+id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
+re='^[1-9][0-9]*$'
+if [[ ! "$id" =~ $re ]]; then
+    echo "ID must a be a positive interger, exiting"
+    exit 1
+fi
+
+if [ ! -e $tgen_dir ]; then
+    echo "ERROR: $tgen_dir not found"
+    exit 1
+fi
+pushd $tgen_dir >/dev/null
+git remote update
+git branch -a
+git checkout crucible1
+git status
+if [ ! -x binary-search.py ]; then
+    echo "ERROR: binary-search.py is missing or not executable"
+    exit 1
+fi
+echo "Laucnhing TRex"
+if [ ! -x launch-trex.sh ]; then
+    echo "ERROR: luanch-trex.sh is missing or not executable"
+    exit 1
+fi
+if [ ! -e /usr/bin/python ]; then
+    echo "/usr/bin/python not found"
+    if [ -e /usr/bin/python3 ]; then
+        echo "creating symlink from /usr/bin/python3"
+        ln -sf /usr/bin/python3 /usr/bin/python
+        /bin/ls -l /usr/bin/python
+    else
+        echo "can't finf /usr/bin/python3 either, exiting"
+        exit 1
+    fi
+fi
+./launch-trex.sh --devices=$devices
+echo "/tmp/trex.server.out:"
+cat /tmp/trex.server.out
+echo
+echo MAC info:
+/usr/bin/python3 ./trex-query.py --device 0 2>&1 | grep "PARSABLE PORT INFO" | sed -e 's/PARSABLE PORT INFO: //' | jq -r '.[0].hw_mac'
+/usr/bin/python3 ./trex-query.py --device 1 2>&1 | grep "PARSABLE PORT INFO" | sed -e 's/PARSABLE PORT INFO: //' | jq -r '.[0].hw_mac'
+echo
+srcmac0=`/usr/bin/python3 ./trex-query.py --device 0 2>&1 | grep "PARSABLE PORT INFO" | sed -e 's/PARSABLE PORT INFO: //' | jq -r '.[0].hw_mac'`
+srcmac1=`/usr/bin/python3 ./trex-query.py --device 1 2>&1 | grep "PARSABLE PORT INFO" | sed -e 's/PARSABLE PORT INFO: //' | jq -r '.[0].hw_mac'`
+echo "TRex source MACs: $srcmac0, $srcmac1"
+# MAC info, to be sent to endpoint and then forwarded to the server 
+popd >/dev/null # back to main client dir where ./msgs is
+echo '{"recipient":{"type":"all","id":"all"},"user-object":{"macs":["'$srcmac0'","'$srcmac1'"]}}' >msgs/tx/macs
+

--- a/trafficgen-post-process
+++ b/trafficgen-post-process
@@ -1,0 +1,95 @@
+#!/usr/bin/perl
+## -*- mode: perl; indent-tabs-mode: t; perl-indent-level: 4 -*-
+## vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=perl
+
+use strict;
+use warnings;
+use JSON::XS;
+use Data::Dumper;
+use Getopt::Long;
+
+my $client_devices;
+my $server_devices;
+my $one_shot;
+my $test_type;
+my $nthreads;
+
+GetOptions ("client-devices=s" => \$client_devices,
+            "server-devices=s" => \$server_devices,
+            "one-shot=i" => \$one_shot
+            );
+
+my @metrics;
+my %metric_types;
+my $primary_metric = 'Mpps';
+my $result_file = "trafficgen-client-stderrout.txt";
+if ( -e $result_file) {
+    open(FH, $result_file) || die "Could not open file " . $result_file;
+    my $ts, my $prev_ts, my $bytes, my $prev_bytes, my $ops, my $prev_ops;;
+    while (<FH>) {
+        # below is from uperf, need to change
+        if ( /^timestamp_ms:(\d+)\.\d+\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)/ ) {
+            $ts = $1, $bytes = $2, $ops = $3;
+            if (defined $prev_ts and ((my $ts_diff = ($ts - $prev_ts) / 1000) > 0)) {
+                {
+                    my %s = ('end' => int $ts,
+                             'value' =>  8.0 * ($bytes - $prev_bytes) / 1000000000 / $ts_diff);
+                    push(@{ $metric_types{'Gbps'}{'data'} }, \%s);
+                }
+                if ($test_type eq "rr") {
+                    $primary_metric = 'transactions-sec';
+                    # RR transactions are two operations
+                    my $tps = ($ops - $prev_ops) / $ts_diff / 2;
+                    {
+                        my %s = ('end' => int $ts, 'value' => 0.0 + $tps);
+                        push(@{ $metric_types{'transactions-sec'}{'data'} }, \%s);
+                    }
+                    if ($tps > 0) {
+                        my %s = ('end' => int $ts, 'value' => 0.0 + $nthreads / $tps *1000000);
+                        push(@{ $metric_types{'round-trip-usec'}{'data'} }, \%s);
+                    }
+                }
+            }
+            $prev_ts = $ts;
+            $prev_bytes = $bytes;
+            $prev_ops = $ops;
+        }
+    }
+    close(FH);
+    # Assign meta-data to any metric data we found and push the data & metadata to the
+    # metrics array
+    for my $type (keys %metric_types) {
+        if (scalar @{ $metric_types{$type}{'data'} } > 0) {
+            my %desc = ('source' => 'uperf', 'type' => $type, 'name-format' => '');
+            if ($type eq "round-trip-usec") {
+                $desc{'class'} = 'count';
+            } else {
+                $desc{'class'} = 'throughput';
+            }
+            if ($type eq "Gbps") {
+                $desc{'name-format'} = "%cmd%";
+                my %names = ('cmd' => 'readandwrite');
+                $metric_types{$type}{'names'} = \%names;
+            }
+            $metric_types{$type}{'desc'} = \%desc;
+            push(@metrics, \%{ $metric_types{$type}});
+        }
+    }
+}
+# Associate the metrics with a benchmark-period (in this case "measurement")
+my %sample;
+my @periods;
+my %period = ('name' => 'measurement');
+$sample{'rickshaw-bench-metric'}{'schema'}{'version'} = "2020.03.18";
+$period{'metrics'} = \@metrics;
+push(@periods, \%period);
+$sample{'periods'} = \@periods;
+$sample{'primary-period'} = 'measurement';
+$sample{'primary-metric'} = $primary_metric;
+if (scalar @metrics > 0) {
+    my $coder = JSON::XS->new;
+    open(JSON_FH, ">post-process-data.json") ||
+        die("Could not open file post-process-data.json for writing\n");
+    print JSON_FH $coder->encode(\%sample);
+    close JSON_FH;
+}

--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -1,0 +1,120 @@
+#!/bin/bash
+exec >trafficgen-server-start-stderrout.txt 
+exec 2>&1
+echo "args; $@"
+echo
+echo "pwd:"
+/bin/pwd
+echo
+echo "ls -alR:"
+ls -alR
+echo
+if [ -z "$RS_CS_LABEL" ]; then
+    echo "RS_CS_LABEL not defined, exiting"
+    exit 1
+else
+    echo "RS_CS_LABEL: $RS_CS_LABEL"
+fi
+echo "hostname: `hostname`"
+echo
+id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
+re='^[1-9][0-9]*$'
+if [[ ! "$id" =~ $re ]]; then
+    echo "ID must a be a positive interger, exiting"
+    exit 1
+fi
+
+# defaults
+forwarder=testpmd
+devices=""
+queues=1
+
+longopts="client-devices:,server-devices:,max-loss-pct:,rate:,rate-unit:,one-shot:"
+opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
+if [ $? -ne 0 ]; then
+    printf -- "\tUnrecognized option specified\n\n"
+    exit 1
+fi
+eval set -- "$opts";
+while true; do
+    case "$1" in
+        --server-devices)
+            shift;
+            devices="$1"
+            shift
+            ;;
+        --client-devices|--one-shot|--rate|--rate-unit)
+            # We don't need these on the server
+            shift;
+            shift
+            ;;
+        --)
+            shift;
+            break
+            ;;
+        *)
+            echo "Invalid option: $1"
+            exit 1
+    esac
+done
+
+id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
+re='^[1-9][0-9]*$'
+if [[ ! "$id" =~ $re ]]; then
+    echo "ID must a be a positive interger, exiting"
+    exit 1
+fi
+
+echo filesystems:
+mount
+echo
+
+echo "ls -l /dev/hugepages"
+/bin/ls -l /dev/hugepages
+echo
+
+echo "/proc/meminfo"
+cat /proc/meminfo
+echo
+
+echo "These files exist in ./msgs/rx:"
+/bin/ls -l msgs/rx
+file="msgs/rx/infra-start:1"
+if [ -e "$file" ]; then
+    echo "Found $file"
+    peermac0=`jq -r '.macs[0]' $file`
+    if [ ! -z "$peermac0" ]; then
+        echo "Found eth-peer MAC0 $peermac0"
+    fi
+    peermac1=`jq -r '.macs[1]' $file`
+    if [ ! -z "$peermac1" ]; then
+        echo "Found eth-peer MAC1 $peermac1"
+    fi
+fi
+
+#testpmd_bin=`which testpmd`
+#if [ -z "$testpmd_bin" -o ! -x $testpmd_bin ]; then
+    #echo "ERROR: $testpmd_bin is not executable or not present"
+#fi
+
+# build cmdline opts for device selection
+devs=""
+for i in `echo $devices | sed -e 's/,/ /g'`; do
+    devs+=" -w $i"
+done
+
+testpmd_bin=/usr/bin/testpmd
+testpmd_opts="--huge-dir /dev/hugepages --socket-mem=1024 -l 10,12,14 $devs"
+testpmd_opts+=" -- --nb-cores 2 -a --stats-period=5"
+testpmd_opts+=" --eth-peer 0,$peermac0 --eth-peer 1,$peermac1 --forward-mode mac"
+
+echo "Going to run: $testpmd_bin $testpmd_opts"
+$testpmd_bin $testpmd_opts >trafficgen-server-stderrout.txt &
+echo $! >> trafficgen-server.pid
+sleep 5
+mac0=`grep "Port 0:" trafficgen-server-stderrout.txt | awk -F"0: " '{print $2}'`
+mac1=`grep "Port 1:" trafficgen-server-stderrout.txt | awk -F"1: " '{print $2}'`
+echo "MAC0: $mac0"
+echo "MAC1: $mac1"
+# MAC info, to be sent to endpoint and then forwarded to the client
+echo '{"recipient":{"type":"all","id":"all"},"user-object":{"macs":["'$mac0'","'$mac1'"]}}' >msgs/tx/svc

--- a/trafficgen-server-stop
+++ b/trafficgen-server-stop
@@ -1,0 +1,20 @@
+#!/bin/bash
+exec >trafficgen-server-stop-stderrout.txt 
+exec 2>&1
+echo "args; $@"
+
+if [ -e trafficgen-server.pid ]; then
+    pid=`cat trafficgen-server.pid`
+    echo "Going to kill pid $pid"
+    kill -15 $pid
+    sleep 3
+    if [ -e /proc/$pid ]; then
+        echo "PID $pid still exists, trying kill -9"
+        kill -9 $pid
+    fi
+else
+    echo "trafficgen-server.pid not found"
+    echo "PWD: `/bin/pwd`"
+    echo "LS: `/bin/ls`"
+    exit 1
+fi

--- a/workshop.json
+++ b/workshop.json
@@ -1,48 +1,53 @@
 {
-    "workshop": {
-	"schema": {
-	    "version": "2020.03.02"
-	}
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenvs": [
+    {
+      "name": "centos8",
+      "requirements": [
+        "dependencies",
+        "trafficgen",
+        "trex",
+        "jq",
+        "dpdk",
+        "dpdk-tools"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "dependencies",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "git",
+          "dpdk-tools",
+          "python3",
+          "tmux",
+          "net-tools"
+        ]
+      }
     },
-    "userenvs": [
-	{
-	    "name": "centos8",
-	    "requirements": [
-		"dependencies",
-		"trafficgen",
-		"trex"
-	    ]
-	}
-    ],
-    "requirements": [
-	{
-	    "name": "dependencies",
-	    "type": "distro",
-	    "distro_info": {
-		"packages": [
-		    "git",
-		    "dpdk-tools",
-		    "python3"
-		]
-	    }
-	},
-	{
-	    "name": "trafficgen",
-	    "type": "manual",
-	    "manual_info": {
-		"commands": [
-		    "git clone https://github.com/atheurer/trafficgen.git /opt/trafficgen"
-		]
-	    }
-	},
-	{
-	    "name": "trex",
-	    "type": "manual",
-	    "manual_info": {
-		"commands": [
-		    "/opt/trafficgen/install-trex.sh --insecure"
-		]
-	    }
-	}
-    ]
+    {
+      "name": "trafficgen",
+      "type": "manual",
+      "manual_info": {
+        "commands": [
+          "git clone https://github.com/atheurer/trafficgen.git /opt/trafficgen"
+        ]
+      }
+    },
+    {
+      "name": "trex",
+      "type": "manual",
+      "manual_info": {
+        "commands": [
+          "/opt/trafficgen/install-trex.sh --insecure"
+        ]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
-This has very limited functionality currently
-This assumes a "L3" type test, where TRex uses a fixed destination
 MAC address, which is determined by getting the MACs from testpmd
-This is the first benchmark to use the  "infra" script, a script
 which is run before the benchmark server is run.  This infra script
 starts TRex server (but not the binary-search) and this allows us
 to get the MACs TRex uses and forward that info to the benchmark
 server, in this case testpmd.
-This still uses a non-master branch of trafficgen git, which we
 will change to master once we confirm all changes are fine.
-There is no post-processing yet.