### PR TITLE
Avoid restarts of TRex in pod and send abort errors

### DIFF
--- a/trafficgen-base
+++ b/trafficgen-base
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+function exit_error() {
+    local msg="$1"; shift
+    local code="$1"; shift
+    if [ -z "$code" ]; then
+        code=1
+    fi
+    echo '{"recipient":{"type":"all","id":"all"},"user-object":{"error": "'$msg'"}}' >msgs/tx/error
+    echo "$msg"
+    exit $code
+}
+
 function dump_runtime() {
     echo env:
     env

--- a/trafficgen-client
+++ b/trafficgen-client
@@ -80,8 +80,7 @@ if [ ! -z "$devices" ]; then
     total_devices=$(echo $devices | sed -e "s/,/ /g" | wc -w)
     #if [ $(echo "${total_devices} % 2" | bc) != 0 ]; then
     if [ $(($total_devices % 2)) != 0 ]; then
-        echo "devices must be supplied in quantities of 2, exiting"
-        exit 1
+        exit_error "devices must be supplied in quantities of 2"
     else
         #total_device_pairs=$(echo "${total_devices} / 2" | bc)
         total_device_pairs=$(($total_devices / 2))
@@ -99,23 +98,18 @@ if [ ! -z "$devices" ]; then
             done
         else
             if [ "${total_device_pairs}" -gt 1 ]; then
-                echo "only the trex-txrx* traffic generators support more than 1 pair of devices, exiting"
-                exit 1
+                exit_error "only the trex-txrx* traffic generators support more than 1 pair of devices"
             fi
         fi
     fi
     total_active_devices=$(echo ${active_devices} | sed -e "s/,/ /g" | wc -w)
-    #if [ $(echo "${total_active_devices} % 2" | bc) -ne 0 ]; then
     if [ $(($total_active_devices % 2)) -ne 0 ]; then
-        echo "active devices must be supplied in quantities of 2, exiting"
-        exit 1
+        exit_error "active devices must be supplied in quantities of 2"
     else
         if [ $traffic_generator != "trex-txrx" -a \
              $traffic_generator != "trex-txrx-profile" -a \
              "${devices}" != "${active_devices}" ]; then
-        #if $(echo $traffic_generator | grep -eq "^trex-txrx") && [ "${devices}" != "${active_devices}" ]; then
-            echo "only the trex-txrx* traffic generators support --client-devices != --active-client-devices, exiting"
-            exit 1
+            exit_error "only the trex-txrx* traffic generators support --client-devices != --active-client-devices"
         else
             if [ $traffic_generator == "trex-txrx" -o $traffic_generator == "trex-txrx-profile" ]; then
                 active_device_pair_index=0
@@ -144,8 +138,7 @@ if [ ! -z "$devices" ]; then
                             fi
                         fi
                     else
-                        echo "couldn't find an active device [${active_device}] in the list of devices [${devices}], exiting"
-                        exit 1
+                        exit_error "Couldn't find an active device [${active_device}] in the list of devices [${devices}]"
                     fi
                 done
             fi
@@ -155,8 +148,7 @@ fi
 
 
 if [ ! -e $tgen_dir ]; then
-    echo "ERROR: $tgen_dir not found"
-    exit 1
+    exit_error "ERROR: $tgen_dir not found"
 fi
 pushd $tgen_dir
 git remote update
@@ -164,8 +156,7 @@ git branch -a
 git checkout crucible1
 git status
 if [ ! -x binary-search.py ]; then
-    echo "ERROR: binary-search.py is missing or not executable"
-    exit 1
+    exit_error "ERROR: binary-search.py is missing or not executable"
 fi
 if [ ! -e /usr/bin/python ]; then
     echo "/usr/bin/python not found"
@@ -174,8 +165,7 @@ if [ ! -e /usr/bin/python ]; then
         ln -sf /usr/bin/python3 /usr/bin/python
         /bin/ls -l /usr/bin/python
     else
-        echo "can't find /usr/bin/python3 either, exiting"
-        exit 1
+        exit_error "can't find /usr/bin/python3, exiting"
     fi
 fi
 
@@ -185,9 +175,27 @@ $cmd
 rc=$?
 popd
 if [ $rc != 0 ]; then
-    exit $rc
+    exit_error "binary-search.py failed"
 fi
 
+if [ "$endpoint" == "k8s" -a "$osruntime" == "pod" ]; then
+    # Don't shutdown TRex, as we can't remove the hugepages in /dev/hugepages after
+    # when using a pod.
+    exit 0
+fi
 echo "Shutting down TRex"
-kill `pgrep _t-rex-64`
-exit 0
+pid_file="$client_dir/trex-server-pid.txt"
+if [ ! -e $pid_file ]; then
+    exit_error "[ERROR] could not find TRex pid file: $pid_file"
+    exit 1
+fi
+pid=`cat $pid_file`
+if [ ! -z "$pid" ]; then
+    kill -s SIGINT $pid || kill -s SIGTERM $pid
+    rc=$?
+    if [ $rc -gt 0 ]; then
+        exit_error "kill of TRex pid $pid failed" $rc
+    fi
+else
+    exit_error "[ERROR] could not find TRex PID in $pid_file"
+fi

--- a/trafficgen-infra
+++ b/trafficgen-infra
@@ -10,6 +10,7 @@ validate_sw_prereqs
 validate_other_prereqs
 
 # defaults
+trex_bin="_t-rex-64-o"
 tgen_dir=/opt/trafficgen
 sample_dir="`/bin/pwd`"
 trex_cfg="$sample_dir/trex_cfg.yaml"
@@ -61,8 +62,7 @@ if [ -z "$active_devices" ]; then
 fi
 
 if [ ! -e $tgen_dir ]; then
-    echo "ERROR: $tgen_dir not found"
-    exit 1
+    exit_error "$tgen_dir not found"
 fi
 pushd $tgen_dir
 git remote update
@@ -70,13 +70,7 @@ git branch -a
 git checkout crucible1
 git status
 if [ ! -x binary-search.py ]; then
-    echo "ERROR: binary-search.py is missing or not executable"
-    exit 1
-fi
-echo "Laucnhing TRex"
-if [ ! -x launch-trex.sh ]; then
-    echo "ERROR: luanch-trex.sh is missing or not executable"
-    exit 1
+    exit_error "binary-search.py is missing or not executable"
 fi
 if [ ! -e /usr/bin/python ]; then
     echo "/usr/bin/python not found"
@@ -85,90 +79,93 @@ if [ ! -e /usr/bin/python ]; then
         ln -sf /usr/bin/python3 /usr/bin/python
         /bin/ls -l /usr/bin/python
     else
-        echo "can't find /usr/bin/python3 either, exiting"
-        exit 1
+        exit_error "cannot find /usr/bin/python3 either, exiting"
     fi
 fi
 popd
 
-if [ -z "$cpus" ]; then
-    # User did not specify CPUs, so use what's available
-    # If this is run on a bare-metal host set up with
-    # cpu-partitioning, this is not going to work.  The
-    # user needs to specify what CPUs to use for TRex.
-    cpus=`get_cpus_allowed`
-fi
-cpus_expanded="`expand_number_list $cpus`"
-cpus_separated="`separate_comma_list $cpus_expanded`"
-echo
-echo "TRex cpus: $cpus_separated"
 
-trex_dir=/opt/trex/current
-
-pushd $trex_dir
-interface_state_cmd="./dpdk_setup_ports.py -t"
-echo "interface status: $interface_state_cmd"
-${interface_state_cmd}
-echo; echo
-echo "Resolving devices for trex based on devices [$devices]"
-trex_dev_opt=""
-for dev in `echo $devices | sed -e 's/,/ /g'`; do
-    res_dev=""
-    resolve_device res_dev $dev
-    trex_dev_opt+=" $res_dev"
-done
-if [ -z "$trex_dev_opt" ]; then
-    "TRex devices could not be found, exiting"
-    exit 1
-fi
-# Infra script does not need to use "active" devices, but
-# we might as well validate it now.
-echo "Resolving *active* devices for trex based on [$active_devices]"
-trex_active_dev_opt=""
-position=1
-for dev in `echo $active_devices | sed -e 's/,/ /g'`; do
-    res_dev=""
-    resolve_device res_dev $dev $position
-    trex_active_dev_opt+=" $res_dev"
-done
-if [ -z "$trex_active_dev_opt" ]; then
-    "TRex active devices could not be found, exiting"
-    exit 1
-fi
-
-trex_dumppci_cmd="./dpdk_setup_ports.py --dump-pci-description"
-echo "getting pci configuration with: $trex_dumppci_cmd"
-$trex_dumppci_cmd
-echo; echo
-trex_config_cmd="./dpdk_setup_ports.py -c $trex_dev_opt --cores-include  $cpus_separated -o $trex_cfg"
-echo "configuring trex with: $trex_config_cmd"
-$trex_config_cmd
-if [ ! -e $trex_cfg ]; then
-    echo "$trex_cfg not found, dpdk_setup_ports.py probably failed, exiting"
-    exit 1
-fi
-echo "ls -l $trex_cfg"
-/bin/ls -l $trex_cfg
-echo
-# set the memory limit so that trex doesn't consume all available hugepages
-sed -i -e '/interfaces.*/a\' -e "  limit_memory: $mem_limit" $trex_cfg
-echo "Contents of $trex_cfg:"
-cat $trex_cfg
-echo
-
-trex_cpus=14
-for cpu_block in $(cat $trex_cfg | grep threads | sed -e "s/\s//g" -e "s/threads://"); do
-    yaml_cpus=$(echo "$cpu_block" | sed -e 's/.*\[\(.*\)\]/\1/' -e 's/,/ /g' | wc -w)
-    if [ $yaml_cpus -lt $trex_cpus ]; then
-        trex_cpus=$yaml_cpus
+echo "Checking for TRex service"
+if pgrep $trex_bin; then
+    echo "TRex launched from previous test"
+else
+    echo "Starting TRex service"
+    if [ -z "$cpus" ]; then
+        # User did not specify CPUs, so use what's available
+        # If this is run on a bare-metal host set up with
+        # cpu-partitioning, this is not going to work.  The
+        # user needs to specify what CPUs to use for TRex.
+        cpus=`get_cpus_allowed`
     fi
-done
+    cpus_expanded="`expand_number_list $cpus`"
+    cpus_separated="`separate_comma_list $cpus_expanded`"
+    echo
+    echo "TRex cpus: $cpus_separated"
 
-trex_server_cmd="./_t-rex-64-o -i -c $trex_cpus --checksum-offload --cfg $trex_cfg --iom 0 -v 4 --prefix trafficgen_trex_ --mlx5-so"
-echo "about to run: $trex_server_cmd"
-$trex_server_cmd 2>&1 >$sample_dir/trex-server-stderrout.txt &
-echo $! >$sample_dir/trex-server-pid.txt
-popd
+    trex_dir=/opt/trex/current
+
+    pushd $trex_dir
+    interface_state_cmd="./dpdk_setup_ports.py -t"
+    echo "interface status: $interface_state_cmd"
+    ${interface_state_cmd}
+    echo; echo
+    echo "Resolving devices for trex based on devices [$devices]"
+    trex_dev_opt=""
+    for dev in `echo $devices | sed -e 's/,/ /g'`; do
+        res_dev=""
+        resolve_device res_dev $dev
+        trex_dev_opt+=" $res_dev"
+    done
+    if [ -z "$trex_dev_opt" ]; then
+        exit_error "TRex devices could not be found"
+    fi
+    # Infra script does not need to use "active" devices, but
+    # we might as well validate it now.
+    echo "Resolving *active* devices for trex based on [$active_devices]"
+    trex_active_dev_opt=""
+    position=1
+    for dev in `echo $active_devices | sed -e 's/,/ /g'`; do
+        res_dev=""
+        resolve_device res_dev $dev $position
+        trex_active_dev_opt+=" $res_dev"
+    done
+    if [ -z "$trex_active_dev_opt" ]; then
+        exit_error "TRex active devices could not be found"
+    fi
+
+    trex_dumppci_cmd="./dpdk_setup_ports.py --dump-pci-description"
+    echo "getting pci configuration with: $trex_dumppci_cmd"
+    $trex_dumppci_cmd
+    echo; echo
+    trex_config_cmd="./dpdk_setup_ports.py -c $trex_dev_opt --cores-include  $cpus_separated -o $trex_cfg"
+    echo "configuring trex with: $trex_config_cmd"
+    $trex_config_cmd
+    if [ ! -e $trex_cfg ]; then
+        exit_error "$trex_cfg not found, dpdk_setup_ports.py probably failed"
+    fi
+    echo "ls -l $trex_cfg"
+    /bin/ls -l $trex_cfg
+    echo
+    # set the memory limit so that trex doesn't consume all available hugepages
+    sed -i -e '/interfaces.*/a\' -e "  limit_memory: $mem_limit" $trex_cfg
+    echo "Contents of $trex_cfg:"
+    cat $trex_cfg
+    echo
+
+    trex_cpus=14
+    for cpu_block in $(cat $trex_cfg | grep threads | sed -e "s/\s//g" -e "s/threads://"); do
+        yaml_cpus=$(echo "$cpu_block" | sed -e 's/.*\[\(.*\)\]/\1/' -e 's/,/ /g' | wc -w)
+        if [ $yaml_cpus -lt $trex_cpus ]; then
+            trex_cpus=$yaml_cpus
+        fi
+    done
+
+    trex_server_cmd="./$trex_bin -i -c $trex_cpus --checksum-offload --cfg $trex_cfg --iom 0 -v 4 --prefix trafficgen_trex_ --mlx5-so --close-at-end"
+    echo "about to run: $trex_server_cmd"
+    $trex_server_cmd 2>&1 >$sample_dir/trex-server-stderrout.txt &
+    echo $! >$sample_dir/trex-server-pid.txt
+    popd
+fi
 
 count=0
 secs=0
@@ -185,13 +182,10 @@ done
 if [ $trex_ready -eq 1 ]; then
     echo "Trex server up after $sec seconds"
 else
-    echo "Trex server failed to start"
-    exit 1
+     exit_error "Trex server failed to start"
 fi
-# wait for Trex devices to initialize
-# TODO: find a more accurate wait algorithm
-sleep 20
 
+sleep 20 # Waiting for device to init
 pushd $tgen_dir
 echo
 echo MAC info:

--- a/trafficgen-post-process
+++ b/trafficgen-post-process
@@ -369,10 +369,8 @@ my @trial_profiler_metrics = (
 
     );
 
-printf "RS_CS_LABEL: %s\n", $ENV{'RS_CS_LABEL'};
 if ($ENV{'RS_CS_LABEL'} =~ /^(client|server)-(\d+)$/) {
     if ($1 eq "server") {
-        print "No server post-processing required, exiting\n";
         exit 0;
     }
 };
@@ -390,7 +388,6 @@ if (! -f $result_file) {
 my $bs_json_ref = get_json_file($result_file);
 for (my $index=0; $index<scalar(@{ $$bs_json_ref{'trials'} }); $index++) {
     my %trial = %{ $$bs_json_ref{'trials'}[$index] };
-    printf "Processing new period: Trial %d\n", $trial{'trial'};
     my $period_name = "trial-" . $trial{'trial'};
     if ($index == (scalar(@{ $$bs_json_ref{'trials'} }) - 1)) {
         $period_name = "measurement";
@@ -401,7 +398,6 @@ for (my $index=0; $index<scalar(@{ $$bs_json_ref{'trials'} }); $index++) {
     my $trial_end = int $trial{'stats'}{'trial_stop'};
     my $trial_begin = int $trial{'stats'}{'trial_start'};
 
-    print "Processing trial pass/fail metrics\n";
     for my $trial_metric ( @trial_metrics ) {
         my $metric_type = $$trial_metric{'type'};
         my $metric_value;
@@ -431,9 +427,7 @@ for (my $index=0; $index<scalar(@{ $$bs_json_ref{'trials'} }); $index++) {
         $metric_types{$metric_type}{'desc'} = \%desc;
         push(@metrics, \%{ $metric_types{$metric_type}});
 
-    print "Processing trial device-pair metrics\n";
     foreach my $dev_pair ( @{ $trial{'trial_params'}{'test_dev_pairs'} } ) {
-        print "Processing device-pair " . $$dev_pair{'tx'} . ":" . $$dev_pair{'rx'} . "\n";
         for my $trial_stats_device_metric ( @trial_stats_device_metrics ) {
             my $metric_type = $$trial_stats_device_metric{'type'};
             my $metric_value;

--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -39,8 +39,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$devices" ]; then
-    echo "Value for --server-devices was not found, exiting"
-    exit 1
+    exit_error "Value for --server-devices was not found, exiting"
 fi
 
 # If --server-devices is "none", then this indicates that the client
@@ -78,8 +77,7 @@ for dev in `echo $devices | sed -e 's/,/ /g'`; do
     testpmd_dev_opt+=" -w $res_dev"
 done
 if [ -z "$testpmd_dev_opt" ]; then
-    "Testpmd devices could not be found, exiting"
-    exit 1
+    exit_error "Testpmd devices could not be found, exiting"
 fi
 
 testpmd_output="trafficgen-testpmd-stderrout.txt"
@@ -91,8 +89,7 @@ testpmd_opts+=" -- --nb-cores 2 -a --stats-period=5"
 if [ "$testpmd_forward_mode" == "mac" ]; then
     # TODO: use regex instead:
     if [ -z "$peermac0" -o -z "$peermac1" ]; then
-        echo "[ERROR] Using forware-mode = mac, but did not get MAC addresses from TREX"
-        exit 1
+        exit_error  "[ERROR] Using forware-mode = mac, but did not get MAC addresses from TREX"
     fi
     testpmd_opts+=" --eth-peer 0,$peermac0 --eth-peer 1,$peermac1 --forward-mode mac"
 else


### PR DESCRIPTION
-I would have like to restart Trex for each test, as we can't guarantee the
 trex devices do not change, but we have an issue with old hugepages
 being left behind by trex, and we can't remove them in a pod.
-All abnormal exits now create an error message to be sent by
 client-server-script.