### PR TITLE
Make teaching packets optional

### DIFF
--- a/rickshaw.json
+++ b/rickshaw.json
@@ -29,7 +29,10 @@
         ],
         "runtime": "trafficgen-get-runtime",
         "infra": "trafficgen-infra",
-        "start": "trafficgen-client"
+        "start": "trafficgen-client",
+        "param_regex": [ "s/(\\s--[^\\s]+)=ON/$1/g",
+                         "s/\\s--[^\\s]+=OFF//g"
+                       ]
     },
     "server": {
         "files-from-controller": [

--- a/trafficgen-client
+++ b/trafficgen-client
@@ -169,7 +169,7 @@ if [ ! -e /usr/bin/python ]; then
     fi
 fi
 
-cmd="./binary-search.py ${passthru_args[@]} --output-dir $client_dir $device_pairs_opt --send-teaching-warmup --send-teaching-measurement"
+cmd="./binary-search.py ${passthru_args[@]} --output-dir $client_dir $device_pairs_opt"
 echo "About to run: $cmd"
 $cmd
 bs_rc=$?


### PR DESCRIPTION
- Remove --send-teaching-warmup and --send-teaching-measurement from
  the default list of parameters sent to binary-search.py

- Add ON/OFF param_regex in rickshaw.json -- this allows for key only
  (as opposed to to key=value) parameters to be controlled via ON/OFF
  values in parameter lists.  This allows for
  --sending-teaching-warmup and --send-teaching-measurement (as well
  as other key only parameters) to be controlled just like any other
  key=value parameter.