### PR TITLE
Remove role related terms from parameters

### DIFF
--- a/trafficgen-client
+++ b/trafficgen-client
@@ -29,14 +29,14 @@ while [ $# -gt 0 ]; do
     fi
     case "$arg" in
         # The following two are needed to determine DPDK device IDs (0,1,2...)
-        --active-client-devices)
+        --active-devices)
             active_devices="$val"
             ;;
-        --client-devices)
+        --devices)
             devices="$val"
             ;;
         # Skip options not intended for binary-search
-        --server-devices|--client-cpus|--testpmd-forward-mode|--client-mem-limit|--testpmd-queues|--testpmd-descriptors|--testpmd-smt|--testpmd-smt-mode)
+        --cpus|--mem-limit)
             ;;
         # All other options should be supported natively by binary-search
         *)

--- a/trafficgen-infra
+++ b/trafficgen-infra
@@ -20,27 +20,27 @@ rate_unit="%"
 one_shot="0"
 # TODO: Auto adjust limit based on actual requirement (which is probably number of interfaces)
 mem_limit=2048
-longopts="active-client-devices:,client-devices:,client-cpus:,client-mem-limit:"
+longopts="active-devices:,devices:,cpus:,mem-limit:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -- "$@");
 eval set -- "$opts";
 while true; do
     case "$1" in
-        --active-client-devices)
+        --active-devices)
             shift
             active_devices=$1
             shift
             ;;
-        --client-mem-limit)
+        --mem-limit)
             shift
             mem_limit=$1
             shift
             ;;
-        --client-devices)
+        --devices)
             shift
             devices=$1
             shift
             ;;
-        --client-cpus)
+        --cpus)
             shift
             cpus=$1
             shift

--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -31,7 +31,7 @@ while [ $# -gt 0 ]; do
     fi
     case "$arg" in
         # The following two are needed to determine DPDK device IDs (0,1,2...)
-        --server-devices)
+        --devices)
             devices="$val"
             ;;
         --testpmd-forward-mode)
@@ -52,9 +52,6 @@ while [ $# -gt 0 ]; do
 	--testpmd-mtu)
 	    testpmd_mtu="$val"
 	    ;;
-        # Skip options not intended for binary-search
-        --client-devices|--active-client-devices|--client-cpus)
-            ;;
     esac
 done
 


### PR DESCRIPTION
- Since multiplex/rickshaw now handles roles we don't need to
  complicate the parameter names