### PR TITLE
Auto detect testpmd bin

### DIFF
--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -173,9 +173,8 @@ if [ -z "${testpmd_mem}" ]; then
     testpmd_mem="1024,1024"
 fi
 
-
 testpmd_output="trafficgen-testpmd-stderrout.txt"
-testpmd_bin=/usr/bin/testpmd
+testpmd_bin=$( command -v dpdk-testpmd || command -v testpmd )
 testpmd_opts=" --lcores ${testpmd_cpus}"
 testpmd_opts+=" --socket-mem ${testpmd_mem}"
 testpmd_opts+=" --huge-dir /dev/hugepages $testpmd_dev_opt"


### PR DESCRIPTION
use command -v bash built-in to detect testpmd binary path:
First look for dpdk-testpmd (dpdk v20), then fallback to testpmd.