### PR TITLE
refine the search for the port MAC addresses

### DIFF
--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -206,8 +206,8 @@ echo "Going to run: $testpmd_bin $testpmd_opts"
 $testpmd_bin $testpmd_opts 2>&1 >$testpmd_output &
 echo $! >> trafficgen-server.pid
 sleep 5 # TODO: need a better wait
-mac0=`grep "Port 0:" $testpmd_output | awk -F"0: " '{print $2}'`
-mac1=`grep "Port 1:" $testpmd_output | awk -F"1: " '{print $2}'`
+mac0=`egrep "Port 0: [A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}" $testpmd_output | awk -F"0: " '{print $2}'`
+mac1=`egrep "Port 1: [A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}" $testpmd_output | awk -F"1: " '{print $2}'`
 echo "MAC0: $mac0"
 echo "MAC1: $mac1"
 # TODO: fail if MACs are not found in testpmd output


### PR DESCRIPTION
- different DPDK drivers have different output when testpmd launches
  and the "Port N: " string is not exclusive to printing the MAC
  address with some drivers