### PR TITLE
Fix --rs-udp cmdline option

### DIFF
--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -231,7 +231,7 @@ else
 fi
 
 if [ "$testpmd_enable_rss_udp" == "on" ]; then
-    testpmd_opts+=" --enable-rss-udp"
+    testpmd_opts+=" --rss-udp"
 elif [ "$testpmd_enable_rss_udp" == "off" ]; then
     echo "--enable-rss-udp will not be used"
 else


### PR DESCRIPTION
Arg is incorrect and makes testpmd to fail.

reference: dpdk ver 21 doc [1]

[1] http://doc.dpdk.org/guides/testpmd_app_ug/run_app.html