### PR TITLE
add support for --traffic-generator=trex-txrx-profile

### DIFF
--- a/rickshaw.json
+++ b/rickshaw.json
@@ -6,10 +6,15 @@
     },
     "benchmark": "trafficgen",
     "controller": {
+        "pre-script": "%bench-dir%/trafficgen-import-profile",
         "post-script": "%bench-dir%trafficgen-post-process"
     },
     "client": {
         "files-from-controller": [
+            {
+                "src": "%run-dir%/trafficgen.profile",
+                "dest": "."
+            },
             {
                 "src": "%bench-dir%/trafficgen-base",
                 "dest": "/usr/bin/"
@@ -53,13 +58,18 @@
             {
                 "src": "%bench-dir%/trafficgen/trex-txrx.py",
                 "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/trafficgen/trex-txrx-profile.py",
+                "dest": "/usr/bin/"
             }
         ],
         "runtime": "trafficgen-get-runtime",
         "infra": "trafficgen-infra",
         "start": "trafficgen-client",
         "param_regex": [ "s/(\\s--[^\\s]+)=ON/$1/g",
-                         "s/\\s--[^\\s]+=OFF//g"
+                         "s/\\s--[^\\s]+=OFF//g",
+                         "s/\\s--traffic-profile=\\S+/ --traffic-profile=trafficgen.profile/"
                        ]
     },
     "server": {

--- a/trafficgen-import-profile
+++ b/trafficgen-import-profile
@@ -1,0 +1,46 @@
+#!/bin/bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+
+traffic_profile=""
+dest_traffic_profile_path="trafficgen.profile"
+
+while [ ! -z ${1} ]; do
+    arg=$(echo ${1} | awk -F= '{ print $1 }')
+    if [ "${arg}" == "--traffic-profile" ]; then
+        traffic_profile=$(echo "${1}" | awk -F= '{ print $2 }')
+        echo "Found traffic profile = ${traffic_profile}"
+    else
+        echo "Ignoring this argument: ${arg}"
+    fi
+    shift
+done
+
+if [ -z "${traffic_profile}" ]; then
+    echo "No traffic profile to import detected"
+
+    # create an empty traffic profile file to satisfy the rickshaw.json client file copy
+    echo "unused/blank trafficgen profile" > ${dest_traffic_profile_path}
+
+    exit 0
+fi
+
+traffic_profile_path=""
+if [ -n "${CRUCIBLE_HOSTFS_PWD}" ]; then
+    echo "Using CRUCIBLE_HOSTFS_PWD=${CRUCIBLE_HOSTFS_PWD}"
+    traffic_profile_path+="/hostfs/"
+    traffic_profile_path+=${CRUCIBLE_HOSTFS_PWD}
+    traffic_profile_path+="/"
+fi
+traffic_profile_path+=${traffic_profile}
+
+if [ ! -e "${traffic_profile_path}" ]; then
+    echo "ERROR: Could not find traffic profile [${traffic_profile_path}]"
+    exit 1
+else
+    echo "Copying traffic profile ${traffic_profile_path} to ${dest_traffic_profile_path}"
+    /bin/cp "${traffic_profile_path}" "${dest_traffic_profile_path}"
+    echo "Contents of ${dest_traffic_profile_path}:"
+    cat ${dest_traffic_profile_path}
+    exit 0
+fi


### PR DESCRIPTION
- The new trafficgen-import-profile script uses the Crucible HOSTFS
  environment variable/mount to find traffic profiles that the user
  has written and specified using --traffic-profile

- The resulting traffic profile (trafficgen.profile) is copied to the
  client for loading at runtime by trex-txrx-profile.py

- The trex-txrx-profile.py is also now copied to the client for
  execution

- The --traffic-profile parameter is rewritten via regex to point to
  the traffic profile that is now embedded in the run directory

- If no traffic profile is specified
  (ie. --traffic-generator=trex-txrx) then a blank/empty traffic
  profile is generated to satisfy rickshaw's client file copy
  requirement.