### PR TITLE
explicitly flag not enough stream flows as an error

### DIFF
--- a/trafficgen/trex-txrx-profile.py
+++ b/trafficgen/trex-txrx-profile.py
@@ -663,6 +663,8 @@ def create_stream (stream, device_pair, direction, other_direction, flow_scaler)
         stream_modes.append('latency')
 
     stream_flows = int(stream['flows'] * flow_scaler)
+    if stream_flows == 0:
+         raise ValueError("There do not appear to be enough flows for the current stream given the configuration (flows=%d | scaler=%f)" % (stream['flows'], flow_scaler))
 
     stream_packets = { 'measurement': [],
                        'teaching': [] }


### PR DESCRIPTION
- The new exception will be raised when a given stream does not have
  enough flows to distribute across all port pairs (ie. 2 port pairs
    but 1 stream flow).  Without this exception a port will be assigned
      a NULL (for lack of a better term) stream that will cause TRex to
        assert.

- If the user really wants a certain flow count (ie. 1) then they must
  reduce the port pairs in use.

- When multiple port pairs are in use, per stream flows must be >=
  port pairs to ensure each port pair gets unique flows.