### PR TITLE
Skip mbuf-factor param

### DIFF
--- a/trafficgen-client
+++ b/trafficgen-client
@@ -35,7 +35,7 @@ while [ $# -gt 0 ]; do
             devices="$val"
             ;;
         # Skip options not intended for binary-search
-        --cpus|--mem-limit|--trex-software-mode|--trex-mellanox-support)
+        --cpus|--mem-limit|--mbuf-factor|--trex-software-mode|--trex-mellanox-support)
             ;;
         # All other options should be supported natively by binary-search
         *)


### PR DESCRIPTION
not used by binary-search.py