### PR TITLE
Allow testpmd pmd-thread to poll more than 1 queue

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -35,6 +35,11 @@
 	    "args": [ "testpmd-queues" ],
 	    "vals": [ "^(1|2|3|4|8)$" ]
 	},
+       "testpmd_queues_per_pmd": {
+           "description": "how many queues each pmd polls",
+           "args": [ "testpmd-queues-per-pmd" ],
+           "vals": [ "^(1|2|3|4|8)$" ]
+       },
 	"testpmd_descriptors": {
 	    "description": "supported testpmd device descriptor counts",
 	    "args": [ "testpmd-descriptors" ],

--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -13,6 +13,7 @@ switch_type="testpmd"
 devices=""
 testpmd_forward_mode="mac"
 testpmd_queues="1"
+testpmd_queues_per_pmd="1"
 testpmd_descriptors="2048"
 testpmd_smt_mode="grouped"
 testpmd_smt="on"
@@ -50,6 +51,9 @@ while [ $# -gt 0 ]; do
             ;;
         --testpmd-queues)
             testpmd_queues="$val"
+            ;;
+        --testpmd-queues-per-pmd)
+            testpmd_queues_per_pmd="$val"
             ;;
         --testpmd-descriptors)
             testpmd_descriptors="$val"
@@ -235,7 +239,7 @@ if [ "$switch_type" == "testpmd" ]; then
 
     echo "Trimming CPU list to match required length:"
     # Number of Ports * Queues per Device
-    WORKLOAD_CPUS_REQUIRED=$(( 2*${testpmd_queues} ))
+    WORKLOAD_CPUS_REQUIRED=$(( 2*${testpmd_queues}/${testpmd_queues_per_pmd} ))
     echo "WORKLOAD_CPUS_REQUIRED=${WORKLOAD_CPUS_REQUIRED}"
     tmp_list="${WORKLOAD_CPUS_SEPARATED}"
     WORKLOAD_CPUS_SEPARATED=""


### PR DESCRIPTION
- default behavior has always been exactly 1 queue per pmd, and for high queue counts this was not always pracitcal.