### PR TITLE
rename some parameters so that it is more obvious/explicit what they …

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -9,7 +9,7 @@
     "validations": {
 	"pci_device_list": {
 	    "description": "1 or more (comma separated) device pairs",
-	    "args": [ "devices", "active-devices" ],
+	    "args": [ "trex-devices", "trex-active-devices", "server-devices" ],
 	    "vals": [
 		"^0{4}(:[0-9a-fA-F]{2}){2}\\.[0-9],0{4}(:[0-9a-fA-F]{2}){2}\\.[0-9](,0{4}(:[0-9a-fA-F]{2}){2}\\.[0-9],0{4}(:[0-9a-fA-F]{2}){2}\\.[0-9])*$",
 		"^VAR:\\w+,VAR:\\w+(,VAR:\\w+,VAR:\\w+)*$"
@@ -17,7 +17,7 @@
 	},
 	"trex_cpus": {
 	    "description": "1 or more (comma separated) cpu or cpu ranges",
-	    "args": [ "cpus" ],
+	    "args": [ "trex-cpus" ],
 	    "vals": [ "^(([0-9]+-[0-9]+)|[0-9]+)(,([0-9]+-[0-9]+|[0-9]+))*$" ]
 	},
 	"trex_on_off_toggles": {
@@ -66,7 +66,7 @@
 	    "description": "any non-zero postive integer value",
 	    "args": [ "frame-size", "num-flows", "teaching-warmup-packet-rate",
 		      "teaching-measurement-packet-rate", "warmup-trial-runtime",
-		      "mem-limit", "testpmd-mtu", "testpmd-burst", "mbuf-factor" ],
+		      "trex-mem-limit", "testpmd-mtu", "testpmd-burst", "trex-mbuf-factor" ],
 	    "vals": [ "^[1-9][0-9]*$" ]
 	},
 	"positive_integer": {

--- a/trafficgen-client
+++ b/trafficgen-client
@@ -28,14 +28,14 @@ while [ $# -gt 0 ]; do
     fi
     case "$arg" in
         # The following two are needed to determine DPDK device IDs (0,1,2...)
-        --active-devices)
+        --trex-active-devices)
             active_devices="$val"
             ;;
-        --devices)
+        --trex-devices)
             devices="$val"
             ;;
         # Skip options not intended for binary-search
-        --cpus|--mem-limit|--mbuf-factor|--trex-software-mode|--trex-mellanox-support)
+        --trex-cpus|--trex-mem-limit|--trex-mbuf-factor|--trex-software-mode|--trex-mellanox-support)
             ;;
         # All other options should be supported natively by binary-search
         *)

--- a/trafficgen-infra
+++ b/trafficgen-infra
@@ -24,7 +24,7 @@ trex_software_mode="off"
 trex_mellanox_support="off"
 mbuf_factor=""
 
-longopts="active-devices:,devices:,cpus:,mem-limit:,trex-software-mode:,trex-mellanox-support:,mbuf-factor:"
+longopts="trex-active-devices:,trex-devices:,trex-cpus:,trex-mem-limit:,trex-software-mode:,trex-mellanox-support:,trex-mbuf-factor:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -- "$@");
 eval set -- "$opts";
 while true; do
@@ -39,27 +39,27 @@ while true; do
 	    trex_software_mode=${1}
 	    shift
 	    ;;
-        --active-devices)
+        --trex-active-devices)
             shift
             active_devices=$1
             shift
             ;;
-        --mem-limit)
+        --trex-mem-limit)
             shift
             mem_limit=$1
             shift
             ;;
-        --devices)
+        --trex-devices)
             shift
             devices=$1
             shift
             ;;
-        --cpus)
+        --trex-cpus)
             shift
             cpus=$1
             shift
             ;;
-        --mbuf-factor)
+        --trex-mbuf-factor)
             shift
             mbuf_factor=" --mbuf-factor $1"
             shift

--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -44,7 +44,7 @@ while [ $# -gt 0 ]; do
             switch_type="$val" # Can be "testpmd" or "null"
             ;;
         # The following two are needed to determine DPDK device IDs (0,1,2...)
-        --devices)
+        --server-devices)
             devices="$val"
             ;;
         --testpmd-forward-mode)


### PR DESCRIPTION
…apply to

- this helps to differentiate between paramters that apply to the infra/client component (TRex) and paramters that apply to the server (currently only testpmd is implemented)