### PR TITLE
feat: support multiple named traffic profiles for trex-txrx-profile

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -58,7 +58,7 @@
 	},
 	"string": {
 	    "description": "any string value",
-	    "args": [ "output-dir", "traffic-profile", "pre-trial-cmd", "warmup-traffic-profile",
+	    "args": [ "output-dir", "traffic-profile", "traffic-profile-name", "pre-trial-cmd", "warmup-traffic-profile", "warmup-traffic-profile-name",
 		      "trex-host", "testpmd-devopt", "trex-config" ],
 	    "vals": [ "^.+$" ]
 	},

--- a/trafficgen/binary-search.py
+++ b/trafficgen/binary-search.py
@@ -38,6 +38,16 @@ def bs_logger(msg, bso = True, prefix = ""):
                                        'prefix':    prefix })
      return(0)
 
+def write_resolved_traffic_profile(profile, output_dir, filename, log_function = print):
+     resolved_path = "%s/%s" % (output_dir, filename)
+     try:
+          streams_only = { 'streams': profile['streams'] }
+          with open(resolved_path, 'w') as fp:
+               json.dump(streams_only, fp, indent=4, separators=(',', ': '), sort_keys=False, default=not_json_serializable)
+          log_function("Wrote resolved traffic profile to %s" % (resolved_path))
+     except:
+          log_function("WARNING: Could not write resolved traffic profile to %s: %s" % (resolved_path, traceback.format_exc()))
+
 def file_open(filename, mode):
      fp = None
 
@@ -494,6 +504,18 @@ def process_options ():
                         default = '',
                         type = str
                         )
+    parser.add_argument('--traffic-profile-name',
+                        dest='traffic_profile_name',
+                        help='When the traffic profile file contains multiple named profiles, select which profile to load (trex-txrx-profile only)',
+                        default = '',
+                        type = str
+                        )
+    parser.add_argument('--warmup-traffic-profile-name',
+                        dest='warmup_traffic_profile_name',
+                        help='Named profile to use with --warmup-traffic-profile during a warmup trial (trex-txrx-profile only)',
+                        default = '',
+                        type = str
+                        )
     parser.add_argument('--disable-upward-search',
                         dest = 'disable_upward_search',
                         help = 'Do not allow binary search to increase beyond the initial rate if it passes final validation',
@@ -880,8 +902,12 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
              cmd = cmd + ' --teaching-measurement-packet-rate=' + str(trial_params['teaching_measurement_packet_rate'])
         if trial_params['trial_mode'] == 'warmup' and len(trial_params['warmup_traffic_profile']):
              cmd = cmd + ' --traffic-profile=' + trial_params['warmup_traffic_profile']
+             if len(trial_params.get('warmup_traffic_profile_name', '')):
+                  cmd = cmd + ' --traffic-profile-name=' + trial_params['warmup_traffic_profile_name']
         else:
              cmd = cmd + ' --traffic-profile=' + trial_params['traffic_profile']
+             if len(trial_params.get('traffic_profile_name', '')):
+                  cmd = cmd + ' --traffic-profile-name=' + trial_params['traffic_profile_name']
         if trial_params['no_promisc']:
              cmd = cmd + ' --no-promisc'
 
@@ -2156,6 +2182,11 @@ def main():
          bs_logger_cleanup(bs_logger_exit, bs_logger_thread)
          return(1)
 
+    if t_global.args.traffic_generator == 'trex-txrx' and (len(t_global.args.traffic_profile_name) or len(t_global.args.warmup_traffic_profile_name)):
+         bs_logger(error("The trex-txrx traffic generator does not support --traffic-profile-name or --warmup-traffic-profile-name"))
+         bs_logger_cleanup(bs_logger_exit, bs_logger_thread)
+         return(1)
+
     if t_global.args.traffic_generator == 'null-txrx' and t_global.args.measure_latency:
          bs_logger(error("The null-txrx traffic generator does not support latency measurements"))
          bs_logger_cleanup(bs_logger_exit, bs_logger_thread)
@@ -2279,6 +2310,8 @@ def main():
          setup_config_var('random_seed', t_global.args.random_seed, trial_params)
          setup_config_var('traffic_profile', t_global.args.traffic_profile, trial_params)
          setup_config_var('warmup_traffic_profile', t_global.args.warmup_traffic_profile, trial_params)
+         setup_config_var('traffic_profile_name', t_global.args.traffic_profile_name, trial_params)
+         setup_config_var('warmup_traffic_profile_name', t_global.args.warmup_traffic_profile_name, trial_params)
          setup_config_var("enable_trex_profiler", t_global.args.enable_trex_profiler, trial_params)
          setup_config_var("trex_profiler_interval", t_global.args.trex_profiler_interval, trial_params)
          setup_config_var('process_all_profiler_data', t_global.args.process_all_profiler_data, trial_params)
@@ -2290,12 +2323,19 @@ def main():
          trial_params['disable_upward_search'] = True
 
     if t_global.args.traffic_generator == 'trex-txrx-profile':
+         _tpn = str(trial_params.get('traffic_profile_name', '') or '').strip()
          trial_params['loaded_traffic_profile'] = load_traffic_profile(traffic_profile = trial_params['traffic_profile'],
                                                                        rate_modifier = 100.0,
-                                                                       log_function = bs_logger)
+                                                                       log_function = bs_logger,
+                                                                       profile_name = _tpn if len(_tpn) else None)
          if trial_params['loaded_traffic_profile'] == 1:
               bs_logger_cleanup(bs_logger_exit, bs_logger_thread)
               return(1)
+
+         write_resolved_traffic_profile(trial_params['loaded_traffic_profile'],
+                                        trial_params['output_dir'],
+                                        "traffic-profile-active.json",
+                                        log_function = bs_logger)
 
          tmp_latency_traffic_direction = trial_params["loaded_traffic_profile"]["streams"][0]["traffic_direction"]
          if tmp_latency_traffic_direction != "bidirectional":
@@ -2308,12 +2348,19 @@ def main():
 
          trial_params['loaded_warmup_traffic_profile'] = None
          if t_global.args.warmup_trial and len(t_global.args.warmup_traffic_profile):
+              _wtpn = str(trial_params.get('warmup_traffic_profile_name', '') or '').strip()
               trial_params['loaded_warmup_traffic_profile'] = load_traffic_profile(traffic_profile = trial_params['warmup_traffic_profile'],
                                                                                    rate_modifier = 100.0,
-                                                                                   log_function = bs_logger)
+                                                                                   log_function = bs_logger,
+                                                                                   profile_name = _wtpn if len(_wtpn) else None)
               if trial_params['loaded_warmup_traffic_profile'] == 1:
                    bs_logger_cleanup(bs_logger_exit, bs_logger_thread)
                    return(1)
+
+              write_resolved_traffic_profile(trial_params['loaded_warmup_traffic_profile'],
+                                             trial_params['output_dir'],
+                                             "warmup-traffic-profile-active.json",
+                                             log_function = bs_logger)
 
               bs_logger("Loaded warmup traffic profile from %s:" % (trial_params['warmup_traffic_profile']))
               bs_logger(dump_json_readable(trial_params['loaded_warmup_traffic_profile']))

--- a/trafficgen/traffic-profile-schema.json
+++ b/trafficgen/traffic-profile-schema.json
@@ -2,127 +2,177 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://raw.githubusercontent.com/perftool-incubator/bench-trafficgen/main/trafficgen/traffic-profile-schema.json",
 
-    "type": "object",
-    "properties": {
-	"streams": {
-	    "type": "array",
-	    "minItems": 1,
-	    "uniqueItems": false,
-	    "items": {
-		"type": "object",
-		"properties": {
-		    "flows": {
-			"type": "integer",
-			"minimum": 1,
-			"maximum": 65536
-		    },
-		    "frame_size": {
-			"type": "integer",
-			"minimum": 40,
-			"maximum": 9218
-		    },
-		    "flow_mods": {
-			"type": "string",
-			"pattern": "^function:create_flow_mod_object\\((\\s*use_(src_mac|dst_mac|src_ip|dst_ip|src_port|dst_port|protocol)_flows\\s*=\\s*(True|False)\\s*,?)+\\)$"
-		    },
-		    "rate": {
-			"type": "integer",
-			"minimum": 0
-		    },
-		    "frame_type": {
-			"type": "string",
-			"enum": [
-			    "generic",
-			    "icmp",
-			    "garp"
-			]
-		    },
-		    "stream_types": {
-			"type": "array",
-			"minItems": 1,
-			"uniqueItems": true,
-			"items": {
-			    "type": "string",
-			    "enum": [
-				"measurement",
-				"teaching_warmup",
-				"teaching_measurement",
-				"ddos"
-			    ]
-			}
-		    },
-		    "latency": {
-			"type": "boolean"
-		    },
-		    "latency_only": {
-			"type": "boolean"
-		    },
-		    "protocol": {
+    "oneOf": [
+	{ "$ref": "#/definitions/legacyTrafficProfile" },
+	{ "$ref": "#/definitions/multiProfileTrafficProfile" }
+    ],
+    "definitions": {
+	"streamItem": {
+	    "type": "object",
+	    "properties": {
+		"flows": {
+		    "type": "integer",
+		    "minimum": 1,
+		    "maximum": 65536
+		},
+		"frame_size": {
+		    "type": "integer",
+		    "minimum": 40,
+		    "maximum": 9218
+		},
+		"flow_mods": {
+		    "type": "string",
+		    "pattern": "^function:create_flow_mod_object\\((\\s*use_(src_mac|dst_mac|src_ip|dst_ip|src_port|dst_port|protocol)_flows\\s*=\\s*(True|False)\\s*,?)+\\)$"
+		},
+		"rate": {
+		    "type": "integer",
+		    "minimum": 0
+		},
+		"frame_type": {
+		    "type": "string",
+		    "enum": [
+			"generic",
+			"icmp",
+			"garp"
+		    ]
+		},
+		"stream_types": {
+		    "type": "array",
+		    "minItems": 1,
+		    "uniqueItems": true,
+		    "items": {
 			"type": "string",
 			"enum": [
-			    "UDP",
-			    "TCP"
+			    "measurement",
+			    "teaching_warmup",
+			    "teaching_measurement",
+			    "ddos"
 			]
-		    },
-		    "traffic_direction": {
-			"type": "string",
-			"enum": [
-			    "bidirectional",
-			    "unidirectional",
-			    "revunidirectional"
-			]
-		    },
-		    "stream_id": {
-			"type": "string",
-			"minLength": 0
-		    },
-		    "offset": {
-			"type": "integer",
-			"minimum": 0
-		    },
-		    "duration": {
-			"type": "integer",
-			"minimum": 1
-		    },
-		    "repeat": {
-			"type": "boolean"
-		    },
-		    "repeat_delay": {
-			"type": "integer",
-			"minimum": 0
-		    },
-		    "repeat_flows": {
-			"type": "boolean"
-		    },
-		    "the_packet": {
-			"type": "string",
-			"pattern": "^scapy:.*$"
-		    },
-		    "device_pairs": {
-			"type": "array",
-			"minItems": 1,
-			"uniqueItems": true,
-			"items": {
-			    "type": "string",
-			    "pattern": "^[0-9]+:[0-9]+$"
-			}
-		    },
-		    "enabled": {
-			"type": "boolean"
 		    }
 		},
-		"additionalProperties": false,
-		"required": [
-		    "flows",
-		    "frame_size",
-		    "flow_mods",
-		    "rate"
-		]
+		"latency": {
+		    "type": "boolean"
+		},
+		"latency_only": {
+		    "type": "boolean"
+		},
+		"protocol": {
+		    "type": "string",
+		    "enum": [
+			"UDP",
+			"TCP"
+		    ]
+		},
+		"traffic_direction": {
+		    "type": "string",
+		    "enum": [
+			"bidirectional",
+			"unidirectional",
+			"revunidirectional"
+		    ]
+		},
+		"stream_id": {
+		    "type": "string",
+		    "minLength": 0
+		},
+		"offset": {
+		    "type": "integer",
+		    "minimum": 0
+		},
+		"duration": {
+		    "type": "integer",
+		    "minimum": 1
+		},
+		"repeat": {
+		    "type": "boolean"
+		},
+		"repeat_delay": {
+		    "type": "integer",
+		    "minimum": 0
+		},
+		"repeat_flows": {
+		    "type": "boolean"
+		},
+		"the_packet": {
+		    "type": "string",
+		    "pattern": "^scapy:.*$"
+		},
+		"device_pairs": {
+		    "type": "array",
+		    "minItems": 1,
+		    "uniqueItems": true,
+		    "items": {
+			"type": "string",
+			"pattern": "^[0-9]+:[0-9]+$"
+		    }
+		},
+		"enabled": {
+		    "type": "boolean"
+		}
+	    },
+	    "additionalProperties": false,
+	    "required": [
+		"flows",
+		"frame_size",
+		"flow_mods",
+		"rate"
+	    ]
+	},
+	"legacyTrafficProfile": {
+	    "type": "object",
+	    "additionalProperties": false,
+	    "required": [
+		"streams"
+	    ],
+	    "properties": {
+		"streams": {
+		    "type": "array",
+		    "minItems": 1,
+		    "uniqueItems": false,
+		    "items": {
+			"$ref": "#/definitions/streamItem"
+		    }
+		}
+	    }
+	},
+	"multiProfileTrafficProfile": {
+	    "type": "object",
+	    "additionalProperties": false,
+	    "required": [
+		"profiles"
+	    ],
+	    "properties": {
+		"default_profile": {
+		    "type": "string",
+		    "minLength": 1
+		},
+		"profiles": {
+		    "type": "array",
+		    "minItems": 1,
+		    "items": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+			    "name",
+			    "streams"
+			],
+			"properties": {
+			    "name": {
+				"type": "string",
+				"minLength": 1
+			    },
+			    "streams": {
+				"type": "array",
+				"minItems": 1,
+				"uniqueItems": false,
+				"items": {
+				    "$ref": "#/definitions/streamItem"
+				}
+			    }
+			}
+		    }
+		}
 	    }
 	}
-    },
-    "additionalProperties": false,
-    "required": [
-	"streams"
-    ]
+    }
 }

--- a/trafficgen/trex-profiles/test/test-multi-profile.json
+++ b/trafficgen/trex-profiles/test/test-multi-profile.json
@@ -1,0 +1,32 @@
+{
+    "default_profile": "small",
+    "profiles": [
+	{
+	    "name": "small",
+	    "streams": [
+		{
+		    "flows": 100,
+		    "frame_size": 64,
+		    "flow_mods": "function:create_flow_mod_object(use_src_ip_flows=True, use_dst_ip_flows=True, use_src_port_flows=True, use_dst_port_flows=True, use_protocol_flows=True)",
+		    "rate": 20,
+		    "frame_type": "icmp",
+		    "stream_types": [
+			"teaching_warmup"
+		    ]
+		}
+	    ]
+	},
+	{
+	    "name": "large",
+	    "streams": [
+		{
+		    "flows": 100,
+		    "frame_size": 1518,
+		    "flow_mods": "function:create_flow_mod_object(use_src_ip_flows=True, use_dst_ip_flows=True, use_src_port_flows=True, use_dst_port_flows=True, use_protocol_flows=True)",
+		    "rate": 500000,
+		    "protocol": "TCP"
+		}
+	    ]
+	}
+    ]
+}

--- a/trafficgen/trex-txrx-profile.py
+++ b/trafficgen/trex-txrx-profile.py
@@ -166,6 +166,12 @@ def process_options ():
                         default = '',
                         type = str
                         )
+    parser.add_argument('--traffic-profile-name',
+                        dest='traffic_profile_name',
+                        help='When the traffic profile file contains multiple named profiles, select which profile to load (ignored for legacy files with top-level streams only)',
+                        default = '',
+                        type = str
+                        )
     parser.add_argument('--random-seed',
                         dest='random_seed',
                         help='Specify a fixed random seed for repeatable results (defaults to not repeatable)',
@@ -1285,8 +1291,9 @@ def main():
     return_value = 1
 
     traffic_profile = load_traffic_profile(traffic_profile = t_global.args.traffic_profile,
-                                           rate_modifier = t_global.args.rate_modifier)
-    if not 'streams' in traffic_profile:
+                                           rate_modifier = t_global.args.rate_modifier,
+                                           profile_name = t_global.args.traffic_profile_name.strip() if t_global.args.traffic_profile_name else None)
+    if traffic_profile == 1 or not 'streams' in traffic_profile:
          return return_value
 
     for stream in traffic_profile['streams']:

--- a/trafficgen/trex_tg_lib.py
+++ b/trafficgen/trex_tg_lib.py
@@ -558,7 +558,7 @@ def process_profile_stream(stream, rate_modifier):
 
     return(0)
 
-def load_traffic_profile (traffic_profile = "", rate_modifier = 100.0, log_function = print):
+def load_traffic_profile (traffic_profile = "", rate_modifier = 100.0, log_function = print, profile_name = None):
      try:
           traffic_profile_fp = open(traffic_profile, 'r')
           profile = json.load(traffic_profile_fp)
@@ -589,6 +589,53 @@ def load_traffic_profile (traffic_profile = "", rate_modifier = 100.0, log_funct
          log_function("EXCEPTION: %s" % traceback.format_exc())
          log_function(error("The loaded JSON traffic profile (%s) failed to validate against the traffic profile schema (%s)" % (traffic_profile, schema_file)))
          return(1)
+
+     try:
+         if 'profiles' in profile:
+              profiles_list = profile['profiles']
+              names_seen = {}
+              for p in profiles_list:
+                   n = p['name']
+                   if n in names_seen:
+                        log_function(error("Duplicate traffic profile name '%s' in %s" % (n, traffic_profile)))
+                        return(1)
+                   names_seen[n] = True
+
+              chosen_streams = None
+              if profile_name is not None and len(str(profile_name).strip()):
+                   want = str(profile_name).strip()
+                   for p in profiles_list:
+                        if p['name'] == want:
+                             chosen_streams = p['streams']
+                             break
+                   if chosen_streams is None:
+                        log_function(error("Traffic profile name '%s' not found in %s" % (want, traffic_profile)))
+                        return(1)
+              else:
+                   default_name = profile.get('default_profile')
+                   if default_name is not None and len(str(default_name).strip()):
+                        dn = str(default_name).strip()
+                        for p in profiles_list:
+                             if p['name'] == dn:
+                                  chosen_streams = p['streams']
+                                  break
+                        if chosen_streams is None:
+                             log_function(error("default_profile '%s' not found in %s" % (dn, traffic_profile)))
+                             return(1)
+                   elif len(profiles_list) == 1:
+                        chosen_streams = profiles_list[0]['streams']
+                   else:
+                        log_function(error("Traffic profile file %s contains multiple named profiles; set default_profile in the JSON or pass profile_name / --traffic-profile-name" % (traffic_profile)))
+                        return(1)
+              profile = { 'streams': chosen_streams }
+         elif 'streams' not in profile:
+              log_function(error("Traffic profile %s is missing 'streams' or 'profiles'" % (traffic_profile)))
+              return(1)
+
+     except:
+          log_function("EXCEPTION: %s" % traceback.format_exc())
+          log_function(error("Could not resolve named traffic profiles from %s" % (traffic_profile)))
+          return(1)
 
      try:
          stream_counter = 0


### PR DESCRIPTION
- Extend traffic-profile-schema.json with one Of: legacy vs multi-profile
- Add profile_name param to load_traffic_profile() in trex_tg_lib.py
- Add --traffic-profile-name CLI arg to binary-search.py and trex-txrx-profile.py
- Add --warmup-traffic-profile-name to binary-search.py
- Write traffic-profile-active.json per iteration as audit artifact
- Register new params in multiplex.json validations
- Add test-multi-profile.json example
- Guard trex-txrx backend from receiving profile-name args"

🤖 Generated with Cursor AI