### PR TITLE
docs: update CLAUDE.md to reflect Python post-processor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,7 @@ Scripts and configuration to run traffic generation benchmarks within the crucib
 
 ## Languages
 - Bash: wrapper scripts (trafficgen-base, trafficgen-client, trafficgen-server-start/stop, trafficgen-infra, trafficgen-import-files)
-- Python: core implementation in `trafficgen/` subdirectory (binary-search.py, tg_lib.py, trex-txrx.py, profile-builder.py, etc.)
-- Perl: trafficgen-post-process
+- Python: core implementation in `trafficgen/` subdirectory (binary-search.py, tg_lib.py, trex-txrx.py, profile-builder.py, etc.) and `trafficgen-post-process.py`
 
 ## Key Files
 | File | Purpose |


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to reflect that post-processor is now Python, not Perl
- Post-processor was ported in PR #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)