### PR TITLE
fix: add permissions and broader event types to fork-check workflow

### DIFF
--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -2,7 +2,11 @@ name: fork-check
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   block-fork-pr:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,7 @@ Scripts and configuration to run traffic generation benchmarks within the crucib
 
 ## Languages
 - Bash: wrapper scripts (trafficgen-base, trafficgen-client, trafficgen-server-start/stop, trafficgen-infra, trafficgen-import-files)
-- Python: core implementation in `trafficgen/` subdirectory (binary-search.py, tg_lib.py, trex-txrx.py, profile-builder.py, etc.)
-- Perl: trafficgen-post-process
+- Python: core implementation in `trafficgen/` subdirectory (binary-search.py, tg_lib.py, trex-txrx.py, profile-builder.py, etc.) and `trafficgen-post-process.py`
 
 ## Key Files
 | File | Purpose |


### PR DESCRIPTION
## Summary

- Add `permissions: issues: write, pull-requests: write` to the fork-check workflow — without these, the GITHUB_TOKEN for `pull_request_target` events from forks only has read permissions, causing the comment and close API calls to fail with 403
- Add `synchronize` and `edited` event types so the workflow also triggers when a fork PR receives new commits or is edited, not just on initial open/reopen

This fixes the fork-check workflow silently failing to close fork PRs (e.g., PR #105).

## Test plan

- [ ] Merge this PR, then edit the title of fork PR #105 — verify the fork-check workflow runs successfully and closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)