### PR TITLE
feat: upgrade default TRex version from v2.87 to v3.04

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ Scripts and configuration to run traffic generation benchmarks within the crucib
 | `trafficgen-post-process` | Parses test JSON into CDM-compliant metrics |
 | `trafficgen/binary-search.py` | Core binary search algorithm for throughput testing |
 | `trafficgen/tg_lib.py` | Traffic generator library |
-| `workshop.json` | Engine image build: TRex, DPDK, and dependencies |
+| `client-workshop.json` | Client engine image: TRex v3.04, DPDK, and dependencies |
+| `server-workshop.json` | Server engine image: dpdk-tools and OS dependencies |
 
 ## Conventions
 - Primary branch is `main`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Name | Description
 -----|------------
 multiplex.json | Defines a set of presets and validations for the traffic generator tool, specifying various options and their valid values, such as device lists, traffic directions, packet protocols, and result output types.
 rickshaw.json | Defines the configuration settings for the trafficgen benchmarking tool, including the paths for required scripts and binaries, and options for the client and server components.
-workshop.json | Configuration file for a workshop environment and contains information on required dependencies and their installation methods,
+client-workshop.json | Client engine image workshop: TRex, build tools, and Python dependencies |
+server-workshop.json | Server engine image workshop: dpdk-tools and OS dependencies,
 
 ## Trafficgen
 

--- a/trafficgen/README-binary-search.md
+++ b/trafficgen/README-binary-search.md
@@ -18,12 +18,12 @@ A script to conduct a binary-search for maximum packet throughput.  This script 
     ```
     # cd /path/to/trafficgen
     # ./install-trex.sh
-    Downloading TRex v2.81 from https://trex-tgn.cisco.com/trex/release/v2.81.tar.gz...
-    installed TRex v2.81 from https://trex-tgn.cisco.com/trex/release/v2.81.tar.gz
+    Downloading TRex v3.04 from https://trex-tgn.cisco.com/trex/release/v3.04.tar.gz...
+    installed TRex v3.04 from https://trex-tgn.cisco.com/trex/release/v3.04.tar.gz
     # ls -l /opt/trex
     total 4
-    lrwxrwxrwx  1 root  root    5 Aug 26 15:27 current -> v2.81
-    drwxr-xr-x 17 33066   25 4096 May  7 12:17 v2.81
+    lrwxrwxrwx  1 root  root    5 ... current -> v3.04
+    drwxr-xr-x 17 ...        ... v3.04
     ```
 
 ## Configuration

--- a/trafficgen/install-trex.sh
+++ b/trafficgen/install-trex.sh
@@ -5,7 +5,7 @@ tgen_dir=$(dirname ${full_script_path})
 
 base_dir="/opt/trex"
 tmp_dir="/tmp"
-trex_ver="v2.87"
+trex_ver="v3.04"
 insecure_curl=0
 force_install=0
 toolbox_url=https://github.com/perftool-incubator/toolbox.git


### PR DESCRIPTION
Upgrade the default TRex version installed in the engine image from v2.87 to v3.04 (DPDK 23.03). This is a minimal change -- 1 line of code + documentation updates.
Discussed and agreed upon in PR https://github.com/perftool-incubator/bench-trafficgen/pull/101 review.

v3.04 improvements over v2.87:
- SACK and cubic/newreno TCP congestion control (v2.96)
- iavf/i40evf SR-IOV VF fix for XXV710 NICs
- DPDK 23.03 with stable i40e driver support
- ASTF get_flow_info() TCP RTT measurement support

Validated on STL and ASTF backends with XXV710, E810, and ConnectX-6.

No functional code changes beyond the version default. workshop.json calls install-trex.sh without --version so it inherits the new default. 

Note: I closed the previous PR https://github.com/perftool-incubator/bench-trafficgen/pull/104 as it created from the fork repo.

🤖 Generated by [Cursor AI](https://cursor.com/)
🤖 Model: Opus 4.6 High