### PR TITLE
feat: split workshop.json into client and server workshop files

### DIFF
--- a/client-workshop.json
+++ b/client-workshop.json
@@ -15,12 +15,6 @@
         "trex1",
         "trex2"
       ]
-    },
-    {
-      "name": "default",
-      "requirements": [
-        "trafficgen-server-os-dependencies"
-      ]
     }
   ],
   "requirements": [
@@ -30,19 +24,6 @@
       "distro_info": {
         "groups": [
           "\"Development Tools\""
-        ]
-      }
-    },
-    {
-      "name": "trafficgen-server-os-dependencies",
-      "type": "distro",
-      "distro_info": {
-        "packages": [
-          "rdma-core-devel",
-          "dpdk-tools",
-          "net-tools",
-          "which",
-          "bc"
         ]
       }
     },

--- a/server-workshop.json
+++ b/server-workshop.json
@@ -1,0 +1,30 @@
+{
+  "workshop": {
+    "schema": {
+      "version": "2020.03.02"
+    }
+  },
+  "userenvs": [
+    {
+      "name": "default",
+      "requirements": [
+        "trafficgen-server-os-dependencies"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "trafficgen-server-os-dependencies",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "rdma-core-devel",
+          "dpdk-tools",
+          "net-tools",
+          "which",
+          "bc"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Split `workshop.json` into `client-workshop.json` (alma8 userenv with TRex, build tools, Python deps) and `server-workshop.json` (default userenv with dpdk-tools)
- Enables rickshaw to build separate, smaller engine images for each role

## Jira
[PERFNFV-174](https://redhat.atlassian.net/browse/PERFNFV-174)

## Depends on
- rickshaw PR #823 (merged)

## Test plan
- [ ] Run trafficgen with client+server — verify both images are sourced correctly
- [ ] Run trafficgen client-only — verify server image is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)