### PR TITLE
feat: add alma8 userenv to server-workshop.json with Python 3.12

### DIFF
--- a/server-workshop.json
+++ b/server-workshop.json
@@ -10,6 +10,13 @@
       "requirements": [
         "trafficgen-server-os-dependencies"
       ]
+    },
+    {
+      "name": "alma8",
+      "requirements": [
+        "trafficgen-server-os-dependencies",
+        "set-python3.12"
+      ]
     }
   ],
   "requirements": [
@@ -23,6 +30,15 @@
           "net-tools",
           "which",
           "bc"
+        ]
+      }
+    },
+    {
+      "name": "set-python3.12",
+      "type": "manual",
+      "manual_info": {
+        "commands": [
+          "alternatives --set python3 /usr/bin/python3.12"
         ]
       }
     }


### PR DESCRIPTION
Alma 8 ships with Python 3.6 as the default python3, but toolbox and trafficgen post-processing depend on Python 3.9+ features and libraries. The server role uses toolbox's Python modules (toolbox.json, toolbox.cdm_metrics) for post-processing, which require a modern Python runtime.

Add an alma8-specific userenv that runs
`alternatives --set python3 /usr/bin/python3.12` to select the correct interpreter, matching the approach already used in client-workshop.json (which sets Python 3.9). This ensures the trafficgen server engine image has a compatible Python version for toolbox imports and post-processing on Alma 8 hosts.