### PR TITLE
feat: write post-process-data.json to postprocess/ directory

### DIFF
--- a/trafficgen-post-process.py
+++ b/trafficgen-post-process.py
@@ -311,7 +311,7 @@ def main():
         "periods": periods,
     }
 
-    _, err = save_json_file("post-process-data.json", sample_data)
+    _, err = save_json_file("postprocess/post-process-data.json", sample_data)
     if err:
         print(f"Failed to write post-process-data.json: {err}")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- Write post-process-data.json to the postprocess/ subdirectory instead of the sample root directory
- Part of the Phase 2 migration for PERFNFV-316 (dedicated postprocess/ directory for all post-processing artifacts)

## Jira
[PERFNFV-316](https://redhat.atlassian.net/browse/PERFNFV-316)

## Depends on
- toolbox PR #117 (merged) — CDMMetrics output_dir
- rickshaw PR #826 (merged) — orchestration creates/cleans postprocess/

🤖 Generated with [Claude Code](https://claude.com/claude-code)