### PR TITLE
docs: add description fields to traffic profile schema

### DIFF
--- a/trafficgen/traffic-profile-schema.json
+++ b/trafficgen/traffic-profile-schema.json
@@ -1,34 +1,48 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://raw.githubusercontent.com/perftool-incubator/bench-trafficgen/main/trafficgen/traffic-profile-schema.json",
+    "title": "Traffic Profile Schema",
+    "description": "Schema for trafficgen traffic profile JSON files.  Supports two formats: a legacy single-profile format with a top-level 'streams' array, and a multi-profile format with named profiles each containing their own streams.",
 
     "oneOf": [
-	{ "$ref": "#/definitions/legacyTrafficProfile" },
-	{ "$ref": "#/definitions/multiProfileTrafficProfile" }
+	{
+	    "description": "Legacy single-profile format with a top-level streams array.",
+	    "$ref": "#/definitions/legacyTrafficProfile"
+	},
+	{
+	    "description": "Multi-profile format with named profiles, each containing their own streams.",
+	    "$ref": "#/definitions/multiProfileTrafficProfile"
+	}
     ],
     "definitions": {
 	"streamItem": {
+	    "description": "A traffic stream definition specifying flow count, frame size, flow modifications, and other packet generation parameters.",
 	    "type": "object",
 	    "properties": {
 		"flows": {
+		    "description": "The number of unique network flows to generate for this stream.",
 		    "type": "integer",
 		    "minimum": 1,
 		    "maximum": 65536
 		},
 		"frame_size": {
+		    "description": "The Ethernet frame size in bytes for packets in this stream.",
 		    "type": "integer",
 		    "minimum": 40,
 		    "maximum": 9218
 		},
 		"flow_mods": {
+		    "description": "A function call string that defines how flows are differentiated by varying source/destination MAC, IP, port, or protocol fields.",
 		    "type": "string",
 		    "pattern": "^function:create_flow_mod_object\\((\\s*use_(src_mac|dst_mac|src_ip|dst_ip|src_port|dst_port|protocol)_flows\\s*=\\s*(True|False)\\s*,?)+\\)$"
 		},
 		"rate": {
+		    "description": "The transmission rate for this stream in millions of packets per second (Mpps).  A value of 0 means line rate.",
 		    "type": "integer",
 		    "minimum": 0
 		},
 		"frame_type": {
+		    "description": "The type of Ethernet frame to generate.  'generic' is a standard data frame, 'icmp' generates ICMP packets, and 'garp' generates gratuitous ARP packets.",
 		    "type": "string",
 		    "enum": [
 			"generic",
@@ -37,10 +51,12 @@
 		    ]
 		},
 		"stream_types": {
+		    "description": "An array of stream type classifications that control when and how this stream is used during testing.",
 		    "type": "array",
 		    "minItems": 1,
 		    "uniqueItems": true,
 		    "items": {
+			"description": "A stream type classification.  'measurement' streams are used for throughput/latency measurement.  'teaching_warmup' and 'teaching_measurement' streams populate MAC/ARP tables.  'ddos' streams simulate denial-of-service traffic patterns.",
 			"type": "string",
 			"enum": [
 			    "measurement",
@@ -51,12 +67,15 @@
 		    }
 		},
 		"latency": {
+		    "description": "Whether to enable latency measurement for this stream.",
 		    "type": "boolean"
 		},
 		"latency_only": {
+		    "description": "Whether this stream should only measure latency without contributing to the throughput measurement.",
 		    "type": "boolean"
 		},
 		"protocol": {
+		    "description": "The transport protocol for packets in this stream.",
 		    "type": "string",
 		    "enum": [
 			"UDP",
@@ -64,6 +83,7 @@
 		    ]
 		},
 		"traffic_direction": {
+		    "description": "The direction of traffic flow.  'bidirectional' sends traffic in both directions simultaneously.  'unidirectional' sends from port 0 to port 1 only.  'revunidirectional' sends from port 1 to port 0 only.",
 		    "type": "string",
 		    "enum": [
 			"bidirectional",
@@ -72,41 +92,51 @@
 		    ]
 		},
 		"stream_id": {
+		    "description": "An optional identifier for this stream, used for tracking and referencing.",
 		    "type": "string",
 		    "minLength": 0
 		},
 		"offset": {
+		    "description": "The time offset in seconds from the start of the test before this stream begins transmitting.",
 		    "type": "integer",
 		    "minimum": 0
 		},
 		"duration": {
+		    "description": "The duration in seconds for which this stream transmits.",
 		    "type": "integer",
 		    "minimum": 1
 		},
 		"repeat": {
+		    "description": "Whether this stream should repeat after its duration expires.",
 		    "type": "boolean"
 		},
 		"repeat_delay": {
+		    "description": "The delay in seconds between repetitions of this stream.",
 		    "type": "integer",
 		    "minimum": 0
 		},
 		"repeat_flows": {
+		    "description": "Whether to reuse the same flow definitions on each repetition or generate new ones.",
 		    "type": "boolean"
 		},
 		"the_packet": {
+		    "description": "A custom packet definition using Scapy syntax, prefixed with 'scapy:'.  Overrides the default packet construction.",
 		    "type": "string",
 		    "pattern": "^scapy:.*$"
 		},
 		"device_pairs": {
+		    "description": "An array of device pair specifications defining which TRex ports to use for this stream.  Each pair is formatted as 'tx_port:rx_port'.",
 		    "type": "array",
 		    "minItems": 1,
 		    "uniqueItems": true,
 		    "items": {
+			"description": "A device pair in 'tx_port:rx_port' format.",
 			"type": "string",
 			"pattern": "^[0-9]+:[0-9]+$"
 		    }
 		},
 		"enabled": {
+		    "description": "Whether this stream is active.  Disabled streams are skipped during test execution.",
 		    "type": "boolean"
 		}
 	    },
@@ -119,6 +149,7 @@
 	    ]
 	},
 	"legacyTrafficProfile": {
+	    "description": "The legacy traffic profile format with a single top-level streams array.",
 	    "type": "object",
 	    "additionalProperties": false,
 	    "required": [
@@ -126,6 +157,7 @@
 	    ],
 	    "properties": {
 		"streams": {
+		    "description": "An array of traffic stream definitions.",
 		    "type": "array",
 		    "minItems": 1,
 		    "uniqueItems": false,
@@ -136,6 +168,7 @@
 	    }
 	},
 	"multiProfileTrafficProfile": {
+	    "description": "The multi-profile traffic profile format with named profiles, each containing their own streams.",
 	    "type": "object",
 	    "additionalProperties": false,
 	    "required": [
@@ -143,13 +176,16 @@
 	    ],
 	    "properties": {
 		"default_profile": {
+		    "description": "The name of the default profile to use when no specific profile is requested.",
 		    "type": "string",
 		    "minLength": 1
 		},
 		"profiles": {
+		    "description": "An array of named traffic profiles, each containing its own set of streams.",
 		    "type": "array",
 		    "minItems": 1,
 		    "items": {
+			"description": "A named traffic profile.",
 			"type": "object",
 			"additionalProperties": false,
 			"required": [
@@ -158,10 +194,12 @@
 			],
 			"properties": {
 			    "name": {
+				"description": "The profile name, used to select this profile at runtime.",
 				"type": "string",
 				"minLength": 1
 			    },
 			    "streams": {
+				"description": "An array of traffic stream definitions for this profile.",
 				"type": "array",
 				"minItems": 1,
 				"uniqueItems": false,


### PR DESCRIPTION
## Summary
- Add title, description, and per-property description fields to `trafficgen/traffic-profile-schema.json`
- Documents stream parameters (flows, frame_size, flow_mods, rate, protocol, traffic_direction, etc.), stream types, legacy vs multi-profile formats, and device pair specifications
- Part of a cross-repo effort to add descriptions to all JSON schemas ([PERFNFV-319](https://redhat.atlassian.net/browse/PERFNFV-319))

## Test plan
- [ ] `python3 -c "import json; json.load(open('trafficgen/traffic-profile-schema.json'))"` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)