### PR TITLE
feat: simplify service discovery using engine infrastructure

### DIFF
--- a/trafficgen-client
+++ b/trafficgen-client
@@ -49,14 +49,13 @@ if [ -z "$active_devices" ]; then
 fi
 
 # Trafficgen-client might need MAC info from the server (testpmd)
+echo "Checking for resolved service info"
 echo "These files exist in ./msgs/rx:"
 /bin/ls -l msgs/rx
-file="msgs/rx/server-start-end:1"
-echo
-cat $file
-echo
+file="msgs/rx/svc"
 if [ -e "$file" ]; then
-    echo "Found $file"
+    echo "Found resolved service info: ${file}"
+    cat $file
     dstmacs=`jq -r '.macs[]' $file | tr "\n" "," | sed -e s/,$//`
     passthru_args+=(" --dst-macs=$dstmacs")
 fi

--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -312,20 +312,20 @@ if [ "$switch_type" == "testpmd" ]; then
         if [ ! -e $testpmd_output ]; then
             exit_error "Could not find testpmd output file: [$testpmd_output]" 1 $sample_dir
         fi
-        echo '{"recipient":{"type":"all","id":"all"},"user-object":{"macs":[' >>msgs/tx/svc
+        local macs_json=""
         dev_idx=0
         while [ $dev_idx -lt $total_devs ]; do
             this_mac=`egrep "Port $dev_idx: [A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}:[A-Fa-f0-9]{2}" $testpmd_output | awk -F"$dev_idx: " '{print $2}'`
             echo "MAC$dev_idx: $this_mac"
-            ## MAC info, to be sent to endpoint and then forwarded to the client
-            echo '"'$this_mac'"' >>msgs/tx/svc
-            if [ $dev_idx -lt $((total_devs-1)) ]; then
-                echo ', ' >>msgs/tx/svc
+            if [ $dev_idx -gt 0 ]; then
+                macs_json="${macs_json},"
             fi
+            macs_json="${macs_json}\"${this_mac}\""
             dev_mac[$dev_idx]=$this_mac
             let dev_idx=$dev_idx+1
         done
-        echo "]}}" >>msgs/tx/svc
+        # Queue MAC info for the engine infrastructure to deliver
+        echo '{"macs":['${macs_json}']}' >msgs/tx/svc
     fi
 elif [ "$switch_type" == "null" ]; then
     echo "Using switch_type null, no setup required"


### PR DESCRIPTION
## Summary
- Server builds MAC payload in a variable and writes raw JSON to `msgs/tx/svc` — no roadblock addressing or multi-line fragment appends
- Client reads resolved service info from `msgs/rx/svc` — no barrier-specific file reference
- Engine infrastructure (rickshaw PR #832) handles message addressing, targeting, and resolution

## Test plan
- [ ] Run trafficgen with testpmd — verify `msgs/rx/svc` exists with correct MACs
- [ ] Verify benchmark completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)