### PR TITLE
fix: Python 3 compatibility, broken regex, and parameter typos

### DIFF
--- a/collapse-buckets.py
+++ b/collapse-buckets.py
@@ -128,7 +128,7 @@ def main():
 
     csv_args=sys.argv
 
-    if len(csv_args) == 0:
+    if len(csv_args) <= 1:
         exit(1)
 
     collapsed_files=[]

--- a/multiplex.json
+++ b/multiplex.json
@@ -52,7 +52,7 @@
 	},
 	"testpmd_on_off_toggles": {
 	    "description": "testpmd options which are toggled with on/off values",
-	    "args": [ "testpmd-smt", "testpmd-enable-scatter", "estpmd-enable-rx-cksum",
+	    "args": [ "testpmd-smt", "testpmd-enable-scatter", "testpmd-enable-rx-cksum",
 		      "testpmd-enable-rss-udp" ],
 	    "vals": [ "^(on|off)$" ]
 	},
@@ -63,7 +63,7 @@
 	    "vals": [ "^.+$" ]
 	},
 	"nonzero_positive_integer": {
-	    "description": "any non-zero postive integer value",
+	    "description": "any non-zero positive integer value",
 	    "args": [ "num-flows", "teaching-warmup-packet-rate",
 		      "teaching-measurement-packet-rate", "warmup-trial-runtime",
 		      "trex-mem-limit", "testpmd-mtu", "testpmd-burst", "trex-mbuf-factor" ],
@@ -85,7 +85,7 @@
 	    "args": [ "src-ports", "dst-ports", "vxlan-ids", "vlan-ids" ],
 	    "vals": [ "^[1-9][0-9]*(,[1-9][0-9]*)*$" ]
 	},
-	"nonezero_positive_float": {
+	"nonzero_positive_float": {
 	    "description": "any non-zero positive floating point value",
 	    "args": [ "search-granularity", "rate", "teaching-measurement-interval", "trex-profiler-interval" ],
 	    "vals": [ "^([1-9][0-9]*\\.?[0-9]*)|(0?\\.[0-9]+)$" ]

--- a/trafficgen-base
+++ b/trafficgen-base
@@ -41,7 +41,7 @@ function resolve_device() {
     pciloc_re='^[0-9,a-f]{4}:[0-9,a-f]{2}:[0-9,a-f]{2}\.[0-9,a-f]{1}$' # 0001:0a.b
     #envvar_re='^VAR:(\w+)[:(\d+)]{0,1}' # VAR:SOME_ENV_VAR or VAR:SOME_ENV_VAR:<number>
     envvar_re='^VAR:(\w+)(:(.+)){0,1}' # VAR:SOME_ENV_VAR or VAR:SOME_ENV_VAR:<number>
-    devtype_re='^([virtio|vf]-\d+)$' # virtio-2
+    devtype_re='^(virtio|vf)-[0-9]+$' # virtio-2
     echo "Resolving device [$dev]"
     if [[ "$dev" =~ $envvar_re ]]; then
         envvar="${BASH_REMATCH[1]}"
@@ -50,12 +50,12 @@ function resolve_device() {
             position=1
         fi
         echo "Device [$dev] matched for environment variable pattern"
-        echo "Looking for environment varible [$envvar]"
+        echo "Looking for environment variable [$envvar]"
         # On some endpoints (k8s/openshift) the device is described as a
         # environment variable.  Users can specify which variable this is
         # in the benchmark params with
         #    "client-devices": "VAR:<varname>,VAR:<varname>"
-        # Addtionally, when specifying the k8s enpoint for a trafficgen
+        # Additionally, when specifying the k8s endpoint for a trafficgen
         # client, the user must include a annotation for the pod which
         # ensures the pass-through device(s) are provisioned to the pod.
         # This of course requires that MULTUS networking is configured
@@ -71,7 +71,7 @@ function resolve_device() {
             #export $envvar="$remaining"
         else
             echo "The variable string [$envvar] does not match any environment variable"
-            echo "Here are all of the envronment variables:"
+            echo "Here are all of the environment variables:"
             env
             echo -e "\n\nExiting"
             exit 1
@@ -80,7 +80,7 @@ function resolve_device() {
         echo "Searching for the Nth virtio or VF device is not yet supported, exiting"
         exit 1
     else
-        echo "Device [$dev] did not match regex for environemnt variable [$envvar_re] or devtype [$devtype_re]"
+        echo "Device [$dev] did not match regex for environment variable [$envvar_re] or devtype [$devtype_re]"
     fi
     # At this point $dev should only be a PCI location ID
     if [[ "$dev" =~ $pciloc_re ]]; then

--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -283,7 +283,7 @@ if [ "$switch_type" == "testpmd" ]; then
     if [ "$testpmd_forward_mode" == "mac" ]; then
         mac_file="msgs/rx/infra-start-end:1"
         if [ -z "$testpmd_dst_macs" ]; then
-            exit_error  "[ERROR] Using forware-mode = mac, but did not get MAC addresses from TREX or --testpmd-dst-macs" 1 "$sample_dir"
+            exit_error  "[ERROR] Using forward-mode = mac, but did not get MAC addresses from TREX or --testpmd-dst-macs" 1 "$sample_dir"
         fi
         idx=0
         for this_mac in `echo $testpmd_dst_macs | sed -e 's/,/ /g'`; do

--- a/trafficgen/trex-txrx.py
+++ b/trafficgen/trex-txrx.py
@@ -318,7 +318,7 @@ def create_traffic_profile (direction, device_pair, rate_multiplier, port_speed)
 
                          if stream_loop_remainder == 0:
                               stream_loops -= 1
-                              stream_loops_remainder = max_uinit32
+                              stream_loops_remainder = max_uint32
                     else:
                          stream_mode_obj = STLTXSingleBurst(pps = stream_pps, total_pkts = stream_total_pkts)
                elif stream_mode == "continuous":
@@ -773,7 +773,7 @@ def segment_monitor(connection, device_pairs, run_ports, normal_exit_event, earl
     except TRexError as e:
          myprint("Segment Monitor: TREXERROR: %s" % e)
 
-    except StandardError as e:
+    except Exception as e:
          myprint("Segment Monitor: STANDARDERROR: %s" % e)
 
     finally:

--- a/trafficgen/trex_tg_lib.py
+++ b/trafficgen/trex_tg_lib.py
@@ -510,9 +510,9 @@ def create_profile_stream (flows = 0,
 def process_profile_stream(stream, rate_modifier):
     for key in stream:
         if not key in [ 'flow_mods', 'the_packet' ]:
-            next
+            continue
 
-        if isinstance(stream[key], basestring):
+        if isinstance(stream[key], str):
             # convert from unicode to string
             stream[key] = str(stream[key])
 
@@ -716,7 +716,7 @@ def trex_profiler (connection, claimed_device_pairs, interval, profiler_pgids, p
      except STLError as e:
           print("TRex Profiler: STLERROR: %s" % e)
 
-     except StandardError as e:
+     except Exception as e:
           print("TRex Profiler: STANDARDERROR: %s" % e)
 
      finally:


### PR DESCRIPTION
## Summary

- **multiplex.json**: estpmd-enable-rx-cksum → testpmd-enable-rx-cksum (missing leading 't'), fixed typos in category names (postive, nonezero)
- **trex-txrx.py**: max_uinit32 → max_uint32 (NameError when packet count exceeds uint32), StandardError → Exception (removed in Python 3)
- **trex_tg_lib.py**: basestring → str (removed in Python 3), next → continue (bare 'next' is a no-op, guard clause never skipped), StandardError → Exception
- **collapse-buckets.py**: len(sys.argv) == 0 → <= 1 (sys.argv always has at least the script name)
- **trafficgen-base**: device type regex used character class '[virtio|vf]' instead of alternation '(virtio|vf)', and '\d' (PCRE) instead of '[0-9]' (POSIX ERE). Also fixed typos in user-facing messages
- **trafficgen-server-start**: forware-mode → forward-mode in error message

Fixes https://github.com/perftool-incubator/bench-trafficgen/issues/117

## Test plan
- [ ] Verify multiplex.json is valid JSON
- [ ] Verify Python files pass syntax check (`python3 -m py_compile`)
- [ ] Test device type regex matches "virtio-2" and "vf-0" patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)