### PR TITLE
fix: reinstall engine pip deps after python3 alternatives change

### DIFF
--- a/client-workshop.json
+++ b/client-workshop.json
@@ -11,6 +11,7 @@
         "dev-tools",
         "trafficgen-client-os-dependencies",
         "set-python3.9",
+        "reinstall-engine-pip-deps",
         "pip",
         "trex1",
         "trex2"
@@ -79,6 +80,16 @@
         "commands": [
           "/usr/bin/install-trex.sh --insecure",
           "/usr/bin/install-moongen.sh"
+        ]
+      }
+    },
+    {
+      "name": "reinstall-engine-pip-deps",
+      "type": "python3",
+      "python3_info": {
+        "packages": [
+          "invoke",
+          "fabric"
         ]
       }
     },


### PR DESCRIPTION
## Summary

- Fix engine bootstrap failure (`ModuleNotFoundError: No module named 'fabric'`) on alma8 caused by Python version mismatch across image build stages

## Root cause

The multi-stage image build pipeline creates a Python version conflict:

1. **Stage 1** (alma8 userenv): Installs `python3.12`. `/usr/bin/python3` → python3.12 via alternatives.
2. **Stage 5** (engine requirements): Pip installs `fabric` and `invoke` into python3.12's site-packages.
3. **Stage 7** (trafficgen::client): Installs `dpdk-tools` (pulls in `python36` as a dependency), then runs `alternatives --set python3 /usr/bin/python3.9`. Now `/usr/bin/python3` → python3.9, but fabric lives in python3.12's site-packages.

At runtime, `bootstrap.py` runs as `python3` (→ 3.9), tries `from fabric import Connection`, fails.

## Fix

Add a `reinstall-engine-pip-deps` requirement after `set-python3.9` that re-installs `invoke` and `fabric` via pip into the now-active python3.9.

## Test plan

- [x] Reproduced the failure on the current code (engine-init-begin roadblock timeout)
- [x] Applied the fix and verified the engine passes init and TRex starts successfully
- [ ] Full trafficgen binary search run completes (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)