### PR TITLE
fix: improve Grout L3 robustness and remove alma9 grout dependency

### DIFF
--- a/server-workshop.json
+++ b/server-workshop.json
@@ -19,14 +19,6 @@
       ]
     },
     {
-      "name": "alma9",
-      "requirements": [
-        "trafficgen-server-os-dependencies",
-        "grout-files",
-        "grout-install"
-      ]
-    },
-    {
       "name": "alma10",
       "requirements": [
         "trafficgen-server-os-dependencies",

--- a/trafficgen-infra
+++ b/trafficgen-infra
@@ -121,9 +121,42 @@ echo "Checking for TRex service"
 active_ver=$(readlink /opt/trex/current 2>/dev/null | xargs basename 2>/dev/null || echo "unknown")
 echo "Using TRex version: ${active_ver}"
 
-if pgrep $trex_bin; then
-    echo "TRex launched from previous test" | tee $sample_dir/trex-server-running.txt
-else
+if trex_pid=$(pgrep $trex_bin | head -1) && [ -n "${trex_pid}" ]; then
+    # Verify the running TRex instance is in the correct mode (STL vs ASTF).
+    # A mode mismatch causes RPC connection failures for all query/control tools.
+    running_has_astf=0
+    if grep -q "\-\-astf" /proc/${trex_pid}/cmdline 2>/dev/null || \
+       tr '\0' ' ' < /proc/${trex_pid}/cmdline 2>/dev/null | grep -q -- "--astf"; then
+        running_has_astf=1
+    fi
+
+    need_astf=0
+    if [ "${traffic_generator}" == "trex-astf" ]; then
+        need_astf=1
+    fi
+
+    if [ ${running_has_astf} -ne ${need_astf} ]; then
+        if [ ${need_astf} -eq 1 ]; then
+            echo "Running TRex is in STL mode but ASTF mode is required — restarting"
+        else
+            echo "Running TRex is in ASTF mode but STL mode is required — restarting"
+        fi
+        kill ${trex_pid} 2>/dev/null
+        for i in $(seq 1 10); do
+            pgrep $trex_bin > /dev/null || break
+            sleep 1
+        done
+        if pgrep $trex_bin > /dev/null; then
+            echo "TRex did not exit after SIGTERM — sending SIGKILL"
+            kill -9 ${trex_pid} 2>/dev/null
+            sleep 1
+        fi
+    else
+        echo "TRex launched from previous test (mode OK)" | tee $sample_dir/trex-server-running.txt
+    fi
+fi
+
+if ! pgrep $trex_bin > /dev/null; then
     echo "Starting TRex service"
 
     trex_dir=/opt/trex/current

--- a/trafficgen-server-start
+++ b/trafficgen-server-start
@@ -465,6 +465,7 @@ elif [ "$switch_type" == "grout" ]; then
             readarray -t trex_macs < <(jq -r '.macs[]' "$infra_file")
             readarray -t trex_ips < <(jq -r 'if .ips then .ips[] else empty end' "$infra_file" 2>/dev/null)
 
+            generated_entries=0
             for ((i=0; i<total_devs && i<${#trex_macs[@]}; i++)); do
                 iface_addr="${grout_ip_array[$i]}"
                 if [ -z "${iface_addr}" ]; then
@@ -493,20 +494,26 @@ print(str(iface.network.network_address + 100))
                     echo "WARNING: No IP for TRex port $i in infra message, derived $peer_ip"
                 fi
 
-                echo "nexthop add l3 iface p${i} address ${peer_ip} mac ${trex_macs[$i]}" >> "${grout_init}"
+                if [ -n "${trex_macs[$i]}" ]; then
+                    echo "nexthop add l3 iface p${i} address ${peer_ip} mac ${trex_macs[$i]}" >> "${grout_init}"
 
-                # Add a gateway route so the entire subnet forwards via this
-                # nexthop. Without this, only the exact peer_ip is covered by
-                # the static entry; other IPs in the range (e.g. ASTF
-                # client/server IP ranges) would fall back to dynamic ARP/NDP.
-                subnet_base=$(python3 -c "
+                    # Add a gateway route so the entire subnet forwards via
+                    # this nexthop. Without this, only the exact peer_ip is
+                    # covered by the static entry; other IPs in the range
+                    # (e.g. ASTF client/server IP ranges) would need dynamic
+                    # ARP/NDP resolution.
+                    subnet_base=$(python3 -c "
 import ipaddress
 iface = ipaddress.ip_interface('${iface_addr}')
 print(str(iface.network.network_address))
 ")
-                echo "route add ${subnet_base}/${subnet_mask} via ${peer_ip}" >> "${grout_init}"
+                    echo "route add ${subnet_base}/${subnet_mask} via ${peer_ip}" >> "${grout_init}"
+                    (( generated_entries++ ))
+                else
+                    echo "WARNING: No MAC for TRex port $i — skipping static nexthop and route (relying on dynamic NDP/ARP)"
+                fi
             done
-            echo "Auto-generated ${#trex_macs[@]} nexthop and gateway route entries"
+            echo "Auto-generated ${generated_entries} of ${#trex_macs[@]} nexthop and gateway route entries"
         else
             echo "WARNING: No infra message found. Grout will rely on dynamic ARP (may not work on i40e/ice)."
         fi


### PR DESCRIPTION
## Summary

- Remove `grout-files` and `grout-install` from alma9 server-workshop requirements — the Grout RPM targets EL10 (requires GLIBC 2.38) and cannot be installed on alma9
- Add TRex STL/ASTF mode mismatch detection in `trafficgen-infra` — when a running TRex instance is in the wrong mode, it is automatically restarted to prevent RPC connection failures
- Guard nexthop and route generation in `trafficgen-server-start` on non-empty MAC addresses — prevents `grcli` parse errors when MAC exchange has not completed

## Test plan

- [x] Run STL test (`grout-l3-multiport-functional-validation.json`) with alma9 client userenv — verify no workshop/GLIBC errors
- [x] Run back-to-back STL then ASTF tests — verify mode mismatch detection triggers restart
- [x] Run with delayed/missing MAC exchange — verify Grout starts without nexthop parse errors
